### PR TITLE
Fix php error

### DIFF
--- a/plugins/main_sections/ms_doubles/ms_doubles.php
+++ b/plugins/main_sections/ms_doubles/ms_doubles.php
@@ -58,7 +58,6 @@ if ($_SESSION['OCS']['mesmachines']){
 	$tab_id_mes_machines=computer_list_by_tag('','ARRAY');
 	if ($tab_id_mes_machines=="ERROR"){
 		echo $l->g(923);
-		break;
 	}
 }else{
 	$tab_id_mes_machines="";


### PR DESCRIPTION
http://php.net/break

break should be used on a loop, not an if statement.
The back parenthesis "}" is the end of the if.

It cause an php fatal error in php7 : 
    PHP Fatal error:  'break' not in the 'loop' or 'switch' context in /usr/share/ocsinventory-reports/ocsreports/plugins/main_sections/ms_doubles/ms_doubles.php on line 52