### PR TITLE
Validate deployment stats for all download enable at once

### DIFF
--- a/plugins/main_sections/ms_teledeploy/ms_tele_stats.php
+++ b/plugins/main_sections/ms_teledeploy/ms_tele_stats.php
@@ -14,7 +14,7 @@ require('require/function_stats.php');
 
 if($_SESSION['OCS']['profile']->getConfigValue('TELEDIFF')=="YES" 
 	and isset($protectedPost["ACTION"]) and $protectedPost["ACTION"] != ''){
-
+	require('require/function_server.php');
 	if( $protectedPost["ACTION"] == "VAL_SUCC") {	
 		$result_line_delete=find_device_line('SUCCESS%',$protectedGet["stat"]);
 	}
@@ -27,11 +27,10 @@ if($_SESSION['OCS']['profile']->getConfigValue('TELEDIFF')=="YES"
 	
 	if (isset($result_line_delete) and is_array($result_line_delete)){
 		require('require/function_telediff.php');
-		desactive_packet($result_line_delete['HARDWARE_ID'],$result_line_delete['IVALUE'][0]);
-	}
-	
-	
-	
+		foreach ($result_line_delete as $key => $value) {
+			desactive_packet($value,$key);
+		}		
+	}	
 }
 
 $form_name="show_stats";

--- a/require/function_stats.php
+++ b/require/function_stats.php
@@ -37,29 +37,43 @@ $arr_FCColors[19] = "669900" ;//Shade of green
 //cyclic iteration to return a color from a given index. The index value is
 //maintained in FC_ColorCounter
 
+function find_ivalues($packid){
+	$sql = "SELECT id FROM download_enable WHERE fileid='%s'";
+	$arg = $packid;
+	$res = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"],$arg);
+	while ($row=mysqli_fetch_array($res)) {
+		$result[] = $row['id'];
+	}
+	return $result;
+}
+
 function find_device_line($status,$packid){
-	
+
+	//get all ivalues
+	$ivalues = find_ivalues($packid);
+
+	//get hardwareid foreach ivalue
+	foreach ($ivalues as $value) {
 		$sql="select hardware_id,ivalue from devices where name='DOWNLOAD' and tvalue";
 		if ($status == "NULL"){
 			$sql.= " IS NULL ";
-			$arg=$packid;
+			$arg = $value;
 		}elseif ($status == "NOTNULL"){
 			$sql.= " IS NOT NULL ";
-			$arg=$packid;
+			$arg = $value;
 		}else{
 			$sql.= " LIKE '%s' ";
-			$arg=array($status,$packid);
+			$arg=array($status,$value);
 		}			
-		$sql.=	"AND ivalue IN (SELECT id FROM download_enable WHERE fileid='%s') " .
+		$sql.=	"AND ivalue='%s' " .
 				"AND hardware_id NOT IN (SELECT id FROM hardware WHERE deviceid='_SYSTEMGROUP_')";
 		
 		$res =mysql2_query_secure($sql, $_SESSION['OCS']["readServer"],$arg);		
 		while ($row=mysqli_fetch_object($res)){
-			$result['HARDWARE_ID'][]=$row->hardware_id;
-			$result['IVALUE'][]=$row->ivalue;
+			$result[$value][]=$row->hardware_id;
 		}
-		return $result;
-	
+	}
+	return $result;
 }
 
 ?>


### PR DESCRIPTION
When using redistribution server, you need to click on the 3 buttons stats (Validate SUCCESSES,Validate all,Unaffect not notified) for each download enable of a package in order to validate stats deployment. 

Exemple : 10 redistributions servers means at least 10 clicks on validate successes (11 if we have a download enable for ocsinventory server).

This pull request convert this to a one click validation for each button stat.