### PR TITLE
Update Japanese translation, fix date format.

### DIFF
--- a/plugins/language/japanese/japanese.txt
+++ b/plugins/language/japanese/japanese.txt
@@ -175,7 +175,7 @@
 264 No label file now
 265 Anything
 266 Invalid date
-267 yyyy/dd/mm
+267 yyyy/mm/dd
 268 速度
 269 %Y/%m/%d
 270 モデム


### PR DESCRIPTION
Fix date format yyyy/dd/mm -> yyyy/mm/dd.
"yyyy/mm/dd" is used usually in Japan.
