### PR TITLE
Update function_wol.php

### DIFF
--- a/require/function_wol.php
+++ b/require/function_wol.php
@@ -27,7 +27,7 @@
 class Wol {
     public $wol_send;
 
-    public function wake($mac) {
+    public function wake($mac,$ip) {
         global $l;
         //looking for values of wol config
         $wol_info = look_config_default_values('WOL_PORT');
@@ -43,7 +43,7 @@ class Wol {
                     $this->wol_send = $l->g(1322);
                 } else {
                     socket_set_option($s, SOL_SOCKET, SO_BROADCAST, true);
-                    socket_sendto($s, $this->pacquet($mac), strlen($this->pacquet($mac)), 0, "255.255.255.255", $v);
+                    socket_sendto($s, $this->pacquet($mac), strlen($this->pacquet($mac)), 0, $ip, $v);
                     socket_close($s);
                     $this->wol_send = $l->g(1282);
                 }


### PR DESCRIPTION
Remplacement du broadcast "255.255.255.255" à la ligne 46 par la variable $ip que j'ai ajoutée à la ligne 30.
Pourquoi ? parce que tous les outils qui fonctionnent (wake on lan, script wol php etc...) envoient sur l'ip et le port 7 ou 9. (vu avec wireshark)

Testé (sur plusieurs postes arrêtés) et fonctionnel. (ocs server windows 2.1.2)