### PR TITLE
Fix order and values NAME and MODEL columns

### DIFF
--- a/plugins/computer_detail/cd_storages/cd_storages.php
+++ b/plugins/computer_detail/cd_storages/cd_storages.php
@@ -32,9 +32,9 @@ $tab_options = $protectedPost;
 $tab_options['form_name'] = $form_name;
 $tab_options['table_name'] = $table_name;
 echo open_form($form_name, '', '', 'form-horizontal');
-$list_fields = array($l->g(49) => 'NAME',
+$list_fields = array($l->g(65) => 'NAME',
     $l->g(64) => 'MANUFACTURER',
-    $l->g(65) => 'MODEL',
+    $l->g(49) => 'MODEL',
     $l->g(53) => 'DESCRIPTION',
     $l->g(66) => 'TYPE',
     $l->g(67) . " (MB)" => 'DISKSIZE',
@@ -43,11 +43,11 @@ $list_fields = array($l->g(49) => 'NAME',
 if ($show_all_column) {
     $list_col_cant_del = $list_fields;
 } else {
-    $list_col_cant_del = array($l->g(49) => $l->g(49));
+    $list_col_cant_del = array($l->g(65) => $l->g(65));
 }
 
 $default_fields = $list_fields;
-$tab_options['FILTRE'] = array('NAME' => $l->g(49), 'MANUFACTURER' => $l->g(64), 'TYPE' => $l->g(66));
+$tab_options['FILTRE'] = array('NAME' => $l->g(65), 'MANUFACTURER' => $l->g(64), 'TYPE' => $l->g(66));
 $queryDetails = "SELECT * FROM storages WHERE (hardware_id=$systemid)";
 ajaxtab_entete_fixe($list_fields, $default_fields, $tab_options, $list_col_cant_del);
 echo close_form();

--- a/plugins/computer_detail/cd_storages/cd_storages.php
+++ b/plugins/computer_detail/cd_storages/cd_storages.php
@@ -32,9 +32,9 @@ $tab_options = $protectedPost;
 $tab_options['form_name'] = $form_name;
 $tab_options['table_name'] = $table_name;
 echo open_form($form_name, '', '', 'form-horizontal');
-$list_fields = array($l->g(65) => 'NAME',
+$list_fields = array($l->g(49) => 'MODEL',
     $l->g(64) => 'MANUFACTURER',
-    $l->g(49) => 'MODEL',
+    $l->g(65) => 'NAME',
     $l->g(53) => 'DESCRIPTION',
     $l->g(66) => 'TYPE',
     $l->g(67) . " (MB)" => 'DISKSIZE',
@@ -43,7 +43,7 @@ $list_fields = array($l->g(65) => 'NAME',
 if ($show_all_column) {
     $list_col_cant_del = $list_fields;
 } else {
-    $list_col_cant_del = array($l->g(65) => $l->g(65));
+    $list_col_cant_del = array($l->g(65) => $l->g(49));
 }
 
 $default_fields = $list_fields;

--- a/plugins/computer_detail/cd_storages/cd_storages.php
+++ b/plugins/computer_detail/cd_storages/cd_storages.php
@@ -43,7 +43,7 @@ $list_fields = array($l->g(49) => 'MODEL',
 if ($show_all_column) {
     $list_col_cant_del = $list_fields;
 } else {
-    $list_col_cant_del = array($l->g(65) => $l->g(49));
+    $list_col_cant_del = array($l->g(65) => $l->g(65));
 }
 
 $default_fields = $list_fields;


### PR DESCRIPTION
On OCS reports GUI, section "All computers" > "Computer" > Hardware > Storage :

 The NAME and MODEL columns are inverted, as are their values.

I think that the first column should be NAME and the third column MODEL.