### PR TITLE
Add network section

### DIFF
--- a/config/computer/menu.xml
+++ b/config/computer/menu.xml
@@ -12,6 +12,10 @@
     <label>g(20)</label>
     <url>cat=software</url>
   </menu-elem>
+  <menu-elem id="network">
+    <label>g(1367)</label>
+    <url>cat=network</url>
+  </menu-elem>
   <menu-elem id="devices">
     <label>g(1331)</label>
     <url>cat=devices</url>

--- a/config/computer/plugins.xml
+++ b/config/computer/plugins.xml
@@ -36,12 +36,6 @@
   	<category>hardware</category>
   	<available>sounds</available>
   </plugin>
-  <plugin id="cd_networks">
-  	<label>g(82)</label>
-  	<system>1</system>
-  	<category>hardware</category>
-  	<available>networks</available>
-  </plugin>
   <plugin id="cd_controllers">
   	<label>g(93)</label>
   	<system>1</system>
@@ -66,7 +60,7 @@
   	<category>hardware</category>
   	<available>bios</available>
   </plugin>
-  
+
   <!-- SOFTWARE -->
   <plugin id="cd_softwares">
   	<label>g(20)</label>
@@ -74,7 +68,15 @@
   	<category>software</category>
   	<available>softwares</available>
   </plugin>
-  
+
+  <!-- NETWORK -->
+  <plugin id="cd_networks">
+    <label>g(82)</label>
+    <system>1</system>
+    <category>network</category>
+    <available>networks</available>
+  </plugin>
+
   <!-- DEVICES -->
   <plugin id="cd_pda">
   	<label>g(994)</label>
@@ -106,7 +108,7 @@
   	<category>devices</category>
   	<available>modems</available>
   </plugin>
-  
+
   <!-- ADMIN -->
   <plugin id="cd_admininfo">
   	<label>g(56)</label>
@@ -126,7 +128,7 @@
   	<category>admin</category>
   	<available>registry</available>
   </plugin>
-  
+
   <!-- CONFIG -->
   <plugin id="cd_configuration">
   	<label>g(500)</label>
@@ -134,7 +136,7 @@
   	<category>config</category>
   	<hide_frame>1</hide_frame>
   </plugin>
-  
+
   <!-- TELEDEPLOY -->
    <plugin id="cd_teledeploy">
   	<label>g(558)</label>
@@ -142,7 +144,7 @@
   	<category>teledeploy</category>
   	<available>teledeploy</available>
   </plugin>
-  
+
   <!-- OTHER -->
   <plugin id="cd_vm">
   	<label>g(1266)</label>

--- a/plugins/main_sections/ms_computer/ms_computer.php
+++ b/plugins/main_sections/ms_computer/ms_computer.php
@@ -86,7 +86,7 @@ if (AJAX) {
 $plugins_serializer = new XMLPluginsSerializer();
 $plugins = $plugins_serializer->unserialize(file_get_contents( CD_CONFIG_DIR .'plugins.xml'));
 
-if (isset($protectedGet['cat']) && in_array($protectedGet['cat'], array('software', 'hardware', 'devices', 'admin', 'config', 'teledeploy', 'other'))) {
+if (isset($protectedGet['cat']) && in_array($protectedGet['cat'], array('software', 'hardware', 'network', 'devices', 'admin', 'config', 'teledeploy', 'other'))) {
     // If category
     foreach ($plugins as $plugin) {
         if ($plugin->getCategory() == $protectedGet['cat']) {


### PR DESCRIPTION
## Status
**READY**

## Description
This PR aim to add a network section in the computer view.
This will split network from hardware data and will permit network related plugins to have their proper section.

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/281

## Todos
- [x] Tests
- [ ] Documentation

#### General informations
Operating system : Debian 9.1

#### Server informations
Php version : 5.6 / 7.1
Mysql / Mariadb / Percona version : Not related
Apache version : 2.4

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Computer tabs in computer view
