### PR TITLE
Add affix on computer menu tab

### DIFF
--- a/plugins/main_sections/ms_computer/ms_computer_views.php
+++ b/plugins/main_sections/ms_computer/ms_computer_views.php
@@ -30,7 +30,7 @@ function show_computer_menu($computer_id) {
 
 
     echo "<div class='left-menu col col-md-2'>";
-    echo "<ul class='nav nav-pills nav-stacked navbar-left'>";
+    echo "<ul class='nav nav-pills nav-stacked navbar-left' data-spy='affix'>";
 
 
     foreach ($menu->getChildren() as $menu_elem) {


### PR DESCRIPTION
## Status
**READY**

## Description
Add affix management on computer menu.
This way, the user will always see the right bar on the left when scrolling down

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/220

## Todos
- [x] Tests

## Test environment
- Firefox Quantum
- Chrome

#### General informations
Operating system : All

#### Server informations
Php version : Not related
Mysql / Mariadb / Percona version : Not related
Apache version : Not related

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Computer view
