### PR TITLE
remove milliseconds from "creation date" tab in ms_tele_activate.php

### DIFF
--- a/plugins/main_sections/ms_teledeploy/ms_tele_activate.php
+++ b/plugins/main_sections/ms_teledeploy/ms_tele_activate.php
@@ -159,7 +159,7 @@ if ($protectedPost['onglet'] == "AVAILABLE_PACKET") {
     }
 
     $list_fields = array($l->g(475) => 'FILEID',
-        $l->g(593) => 'from_unixtime(FILEID)',
+        $l->g(593) => 'CAST(from_unixtime(FILEID) AS DATETIME(0))',
         'SHOWACTIVE' => 'NAME',
         $l->g(440) => 'PRIORITY',
         $l->g(464) => 'FRAGMENTS',


### PR DESCRIPTION
## Status
**READY/NEED TEST**

Should be tested in an environment with Mysql lower than 5.6.4

## Description
From MySQL 5.6.4, datetime objects store milliseconds information by default. This result in an uglyly formated creation dates in ms_tele_activate.php (something like this '2010-12-10 14:12:09.000000').

This commit fixes the issue by casting the datetime objects created to datetime(0) objects which don't store milliseconds information.

## Related Issues
Not reported

## Todos
- [* ] Tests

Should be tested in an environment with Mysql lower than 5.6.4

## Test environment

Tested with OCSI version 2.4

#### General informations
Operating system : Ubuntu 16.04.3

#### Server informations
Php version :   1:7.0+35ubuntu6
Mysql / Mariadb / Percona version : 5.7.20-0ubuntu0.16.04.1 (Should be tested in an environment with Mysql lower than 5.6.4)
Apache version : 2.4.18-2ubuntu3.5

## Deploy Notes
Nothing expected

## Impacted Areas in Application
ms_tele_activate.php