### PR TITLE
Missing argument 2 for Wol::wake()

### DIFF
--- a/plugins/main_sections/ms_computer/ms_computer.php
+++ b/plugins/main_sections/ms_computer/ms_computer.php
@@ -69,7 +69,7 @@ if (isset($protectedPost["WOL"]) && $protectedPost["WOL"] == 'WOL' && $_SESSION[
     $msg = "";
 
     while ($item = mysqli_fetch_object($resultDetails)) {
-        $wol->wake($item->MACADDR);
+        $wol->wake($item->MACADDR,$item->IPADDRESS);
 
         if ($wol->wol_send == $l->g(1282)) {
             msg_info($wol->wol_send . "=>" . $item->MACADDR . "/" . $item->IPADDRESS);


### PR DESCRIPTION
 called in /usr/share/ocsinventory-reports/ocsreports/plugins/main_sections/ms_computer/ms_computer.php on line 72 and defined in /usr/share/ocsinventory-reports/ocsreports/require/function_wol.php on line 30

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Issues
Put here all the related issues link

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :

#### Server informations
Php version :
Mysql / Mariadb / Percona version :
Apache version :

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

*
