### PR TITLE
Move SNMP device link on MAC Address because name is not always set

### DIFF
--- a/plugins/main_sections/ms_snmp/ms_snmp.php
+++ b/plugins/main_sections/ms_snmp/ms_snmp.php
@@ -73,8 +73,8 @@ $queryDetails = $sql['SQL'] . ",ID from snmp s
 $tab_options['LBL_POPUP']['SUP'] = 'NAME';
 $tab_options['LBL']['SUP'] = $l->g(122);
 
-$tab_options['LIEN_LBL']['NAME_SNMP'] = 'index.php?' . PAG_INDEX . '=' . $pages_refs['ms_snmp_detail'] . '&head=1&id=';
-$tab_options['LIEN_CHAMP']['NAME_SNMP'] = 'ID';
+$tab_options['LIEN_LBL'][$l->g(95)] = 'index.php?' . PAG_INDEX . '=' . $pages_refs['ms_snmp_detail'] . '&head=1&id=';
+$tab_options['LIEN_CHAMP'][$l->g(95)] = 'ID';
 $tab_options['LBL']['NAME_SNMP'] = $l->g(49);
 ajaxtab_entete_fixe($list_fields, $default_fields, $tab_options, $list_col_cant_del);
 $img['image/delete.png'] = $l->g(162);


### PR DESCRIPTION
## Status
**READY**

## Description
Move SNMP device link on MAC Address because name is not always set
The current behavior set the link on the Name which can be troublesome if the name is not retrieved by the snmp scanner (Mib not enabled for example)

## Impacted Areas in Application
List general components of the application that this PR will affect:

* SNMP DEVICE List page
