### PR TITLE
Fix ipdiscover incorrect percentage calculation

### DIFF
--- a/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
+++ b/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
@@ -80,7 +80,7 @@ if (isset($protectedPost['DPT_CHOISE']) && $protectedPost['DPT_CHOISE'] != '0') 
 					  non_ident.c as 'NON_INVENTORIE',
 					  ipdiscover.c as 'IPDISCOVER',
 					  ident.c as 'IDENTIFIE',
-					  CASE WHEN ident.c IS NULL and ipdiscover.c IS NULL THEN 100 WHEN ident.c IS NULL THEN round(inv.c * 100 / non_ident.c,1) ELSE round((inv.c + ident.c) * 100 / non_ident.c,1) END as 'pourcentage'
+					  CASE WHEN ident.c IS NULL and ipdiscover.c IS NULL THEN 100 WHEN non_ident.c IS NULL and ipdiscover.c IS NOT NULL THEN 100 WHEN ident.c IS NULL THEN round(inv.c * 100 / (non_ident.c + inv.c),1) ELSE round((inv.c + ident.c) * 100 / (non_ident.c + inv.c),1) END as 'pourcentage'
 			  from (SELECT COUNT(DISTINCT hardware_id) as c,'IPDISCOVER' as TYPE,tvalue as RSX
 					FROM devices
 					WHERE name='IPDISCOVER' and tvalue in  ";


### PR DESCRIPTION
## Status
**READY**

## Description
Fix ipdiscover incorrect percentage calculation

## Todos
- [x] Tests

## Test environment

#### General informations
Operating system : CentOS Linux 7 (Core)

#### Server informations
Php version : 7.1.16
Mysql version : 5.7.22
Apache version : 2.4.6

## Screenshots
### Before
![default](https://user-images.githubusercontent.com/5281753/39662476-7014a978-506a-11e8-8c03-ab73d1502156.png)

### After
![default](https://user-images.githubusercontent.com/5281753/39662480-7f1181e4-506a-11e8-9fa6-796239826015.png)
