### PR TITLE
Name and Model Revert

### DIFF
--- a/plugins/computer_detail/cd_storages/cd_storages.php
+++ b/plugins/computer_detail/cd_storages/cd_storages.php
@@ -32,9 +32,9 @@ $tab_options = $protectedPost;
 $tab_options['form_name'] = $form_name;
 $tab_options['table_name'] = $table_name;
 echo open_form($form_name, '', '', 'form-horizontal');
-$list_fields = array($l->g(49) => 'MODEL',
+$list_fields = array($l->g(49) => 'NAME',
     $l->g(64) => 'MANUFACTURER',
-    $l->g(65) => 'NAME',
+    $l->g(65) => 'MODEL',
     $l->g(53) => 'DESCRIPTION',
     $l->g(66) => 'TYPE',
     $l->g(67) . " (MB)" => 'DISKSIZE',
@@ -43,11 +43,11 @@ $list_fields = array($l->g(49) => 'MODEL',
 if ($show_all_column) {
     $list_col_cant_del = $list_fields;
 } else {
-    $list_col_cant_del = array($l->g(65) => $l->g(65));
+    $list_col_cant_del = array($l->g(49) => $l->g(49));
 }
 
 $default_fields = $list_fields;
-$tab_options['FILTRE'] = array('NAME' => $l->g(65), 'MANUFACTURER' => $l->g(64), 'TYPE' => $l->g(66));
+$tab_options['FILTRE'] = array('NAME' => $l->g(49), 'MANUFACTURER' => $l->g(64), 'TYPE' => $l->g(66));
 $queryDetails = "SELECT * FROM storages WHERE (hardware_id=$systemid)";
 ajaxtab_entete_fixe($list_fields, $default_fields, $tab_options, $list_col_cant_del);
 echo close_form();


### PR DESCRIPTION

## Status
READY

## Description
Model and Name are switched in https://github.com/OCSInventory-NG/OCSInventory-ocsreports/pull/276 but this is not correct so I reverted it.

As I know $l->g(49) revers to the language file on position 49.
If I take look at this files I get Name at 49 and Modell at 65.
I tested it with Version 2.4.1 of OCSInventory-ocsreports:

XML File:
`<STORAGES>
<DESCRIPTION>SATA 3.0 Gb/s</DESCRIPTION>
<DISKSIZE>953869 MB</DISKSIZE>
<FIRMWARE>01.01V02</FIRMWARE>
<MANUFACTURER>Western Digital</MANUFACTURER>
<MODEL>WD1003FBYX-01Y7B</MODEL>
<NAME>TEST-Teil1</NAME>
<SERIALNUMBER>WD-WCAW36724486</SERIALNUMBER>
<TYPE>drive</TYPE>
</STORAGES>`

befor revert:
![fehler](https://user-images.githubusercontent.com/36632383/39700775-c31e67e0-51fe-11e8-8ff0-e6e1cbf62078.png)

after revert:
![ok](https://user-images.githubusercontent.com/36632383/39700785-ca591d70-51fe-11e8-962f-36f821e15b49.png)


## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/pull/276

#### General informations
Operating system : CentOS Linux 7 (Core)

#### Server informations
Php version : PHP/5.4.16 
Mysql / Mariadb / Percona version : MariaDB Server version 5.5.56-MariaDB2.4.1
Apache version : Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips 


## Impacted Areas in Application
List general components of the application that this PR will affect:

* plugins/computer_detail/cd_storages/cd_storages.php
