### PR TITLE
St cyr issue 446: fixed 2 deployement related queries

### DIFF
--- a/plugins/main_sections/ms_multi_search/ms_multi_search.php.back
+++ b/plugins/main_sections/ms_multi_search/ms_multi_search.php.back
@@ -429,7 +429,7 @@ if ($_SESSION['OCS']['DEBUG'] == 'ON'){
  				//requete pour trouver tous les ID
  				//dans ce cas, le champ de recherche doit etre à null
 				if ($original_field_value_complement == $l->g(482))
-					$tvalue = " AND TVALUE IS NULL ";
+					$tvalue = " AND TVALUE IS NULL AND HARDWARE_ID NOT IN (SELECT id FROM hardware WHERE deviceid='_SYSTEMGROUP_' or deviceid='_DOWNLOADGROUP_')";
 				//gestion de TOUT SAUF SUCCESS
 				elseif ($original_field_value_complement == "***".$l->g(548)."***")
 					$tvalue=" AND TVALUE not like 'SUC%' ";

--- a/plugins/main_sections/ms_teledeploy/ms_tele_activate.php
+++ b/plugins/main_sections/ms_teledeploy/ms_tele_activate.php
@@ -247,7 +247,7 @@ if ($protectedPost['onglet'] == "AVAILABLE_PACKET") {
         $sql_data_fixe_bis = "select count(*) as %s,de.FILEID
                                     from devices d,download_enable de
                                     where d.IVALUE=de.ID  and d.name='DOWNLOAD'
-                                    and d.tvalue %s  ";
+                                    and hardware_id NOT IN (SELECT id FROM hardware WHERE deviceid='_SYSTEMGROUP_' or deviceid='_DOWNLOADGROUP_') and d.tvalue %s  ";
         $sql_data_fixe_ter = "select count(*) as %s,de.FILEID
                                     from devices d,download_enable de
                                     where d.IVALUE=de.ID  and d.name='DOWNLOAD'


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes 2 deployement related queries where the reported number of computers waiting notification for a deployement was off by 1 to the actual real number.

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/446

## Todos
- [ ] Tests: I don't think it is needed (but it might be worth peer-reviewing the updated queries)
- [ ] Documentation: Not needed

## Test environment

#### General informations
Operating system : Ubuntu 16.04.4

#### Server informations
Php version : PHP 7.0
Mysql / Mariadb / Percona version : 5.7.22
Apache version : 2.4.18

## Deploy Notes
None

## Impacted Areas in Application
deployment stats

*
