### PR TITLE
Fix some array functions warnings

### DIFF
--- a/plugins/main_sections/ms_computer/ms_computer_views.php
+++ b/plugins/main_sections/ms_computer/ms_computer_views.php
@@ -106,6 +106,8 @@ function show_computer_summary($computer) {
         'AGENT' => $l->g(1390),
     );
 
+    $link = array();
+
     foreach ($labels as $cat) {
         foreach ($cat as $key => $lbl) {
             if ($key == "MEMORY") {

--- a/require/function_search.php
+++ b/require/function_search.php
@@ -601,7 +601,7 @@ function add_trait_select($img,$list_id,$form_name,$list_pag,$comp = false)
             array_push($name, $arg);
         }
         $result = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"], $arg);
-        while ($item = mysqli_fetch_object($result)) {
+        if($result) while ($item = mysqli_fetch_object($result)) {
             $res[$item->id] = $item->name;
         }
         return $res;
@@ -614,7 +614,7 @@ function add_trait_select($img,$list_id,$form_name,$list_pag,$comp = false)
         $arg = array();
         $sql = mysql2_prepare($sql, $arg, $list_id);
         $result = mysql2_query_secure($sql['SQL'], $_SESSION['OCS']["readServer"], $sql['ARG']);
-        while ($item = mysqli_fetch_object($result)) {
+        if($result) while ($item = mysqli_fetch_object($result)) {
             $res[$item->id] = $item->id;
         }
         return $res;

--- a/require/function_telediff.php
+++ b/require/function_telediff.php
@@ -222,6 +222,8 @@ function activ_pack($fileid, $https_server, $file_serv) {
 		$reqEnable = "SELECT * FROM download_enable WHERE fileid=%s";
 		$argEnable = array($fileid);
 		$result = mysql2_query_secure($reqEnable, $_SESSION['OCS']["readServer"], $argEnable);
+		$listInfoLoc = array();
+		$listPackLoc = array();
 		while($recVerif = mysqli_fetch_array($result)){
 				$listInfoLoc[] = $recVerif['INFO_LOC'];
 				$listPackLoc[] = $recVerif['PACK_LOC'];


### PR DESCRIPTION
## Status
READY

## Description
* Fix computer summary warnings on array functions because var not set
* Fix deploy package activation warnings on array functions because var not set
* Fix warnings in multi search when empty result

```
[Fri Aug 03 11:04:52.934187 2018] [:error] [pid 24175] [client 127.0.0.1:48530] PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in /var/www/www/ocs/ocsreports/plugins/main_sections/ms_computer/ms_computer_views.php on line 183, referer: https://127.0.0.1/ocs/ocsreports/index.php?function=visu_computers
[Fri Aug 03 11:02:55.847627 2018] [:error] [pid 24253] [client 127.0.0.1:48506] PHP Warning:  in_array() expects parameter 2 to be array, null given in /var/www/www/ocs/ocsreports/require/function_telediff.php on line 230, referer: https://127.0.0.1/ocs/ocsreports/index.php?function=tele_popup_active&head=1&active=1529428595
```

## Related Issues
#387
