### PR TITLE
Fix broken deploy stats links

### DIFF
--- a/plugins/main_sections/ms_teledeploy/ms_tele_stats.php
+++ b/plugins/main_sections/ms_teledeploy/ms_tele_stats.php
@@ -98,19 +98,25 @@ $sqlStats = "SELECT COUNT(id) as nb, tvalue as txt
 					AND hardware_id NOT IN (SELECT id FROM hardware WHERE deviceid='_SYSTEMGROUP_' or deviceid='_DOWNLOADGROUP_')
 					and tvalue is null";
 
-$arg = array($arg, 'EXIT_CODE%', 'ERR%', $l->g(573), $arg, 'EXIT_CODE%', 'ERR%', $l->g(482), $arg);
+$arg = array($arg, 'EXIT_CODE%', 'ERR%', 'ERRORS', $arg, 'EXIT_CODE%', 'ERR%', 'WAITING', $arg);
 $resStats = mysql2_query_secure($sqlStats . " ORDER BY nb DESC", $_SESSION['OCS']["readServer"], $arg);
 $i = 0;
 while ($row = mysqli_fetch_object($resStats)) {
     $txt_status = strtoupper($row->txt);
     $name_value[$i] = $txt_status;
+    $link[$i] = $txt_status;
+
+    $lang = array(
+        'ERRORS' => 956,
+        'NOTIFIED' => 1000,
+        'SUCCESS' => 572,
+        'WAITING' => 482,
+    );
+    if(isset($lang[$txt_status]))
+        $name_value[$i] = strtoupper($l->g($lang[$txt_status]));
+
     $pourc = round(($row->nb * 100) / $total, 2);
     $legend[$i] = $name_value[$i] . " (" . $pourc . "%)";
-    if ($name_value[$i] == strtoupper($l->g(573))) {
-        $link[$i] = "***" . $l->g(956) . "***";
-    } else {
-        $link[$i] = $name_value[$i];
-    }
     $lbl[$i] = $name_value[$i] . "<br>(" . $pourc . "%)";
     $count_value[$i] = $row->nb;
     if (isset($arr_FCColors[$i])) {

--- a/require/search/Search.php
+++ b/require/search/Search.php
@@ -691,25 +691,12 @@
             break;
 
           case 'stat':
-            if(!array_key_exists('stat',$_SESSION['OCS']['multi_search']['devices'])){
+            {
               $_SESSION['OCS']['multi_search'] = array();
               $_SESSION['OCS']['multi_search']['devices']['stat'] = [
                   'fields' => 'NAME',
                   'value' => 'DOWNLOAD',
                   'operator' => 'EQUAL',
-              ];
-              if($option['stat'] == 'SUCCESS'){
-                $value_stat = 'SUCCESS';
-                $operator_stat = 'EQUAL';
-              }elseif($option['stat'] == 'WAITING NOTIFICATION'){
-                $value_stat = '';
-                $operator_stat = 'ISNULL';
-              }
-
-              $_SESSION['OCS']['multi_search']['devices']['stattvalue'] = [
-                  'fields' => 'TVALUE',
-                  'value' => $value_stat,
-                  'operator' => $operator_stat,
               ];
 
               $i = 0;
@@ -727,6 +714,41 @@
                 ];
                 $i++;
               }
+
+              $comparator = 'AND';
+
+              if($option['stat'] == 'WAITING')
+              {
+                $value_stat = '';
+                $operator_stat = 'ISNULL';
+              }
+              else if($option['stat'] == 'ERRORS')
+              {
+                $value_stat = 'EXIT_CODE';
+                $operator_stat = 'LIKE';
+
+                $_SESSION['OCS']['multi_search']['devices']['stattvalue2'] = [
+                    'fields' => 'TVALUE',
+                    'value' => $value_stat,
+                    'operator' => $operator_stat,
+                    'comparator' => $comparator
+                ];
+
+                $value_stat = 'ERR';
+                $comparator = 'OR';
+              }
+              else
+              {
+                $value_stat = $option['stat'];
+                $operator_stat = 'EQUAL';
+              }
+
+              $_SESSION['OCS']['multi_search']['devices']['stattvalue'] = [
+                  'fields' => 'TVALUE',
+                  'value' => $value_stat,
+                  'operator' => $operator_stat,
+                  'comparator' => $comparator
+              ];
             }
             break;
 


### PR DESCRIPTION
## Status
READY

## Description
Deploy Stats links is broken on 2.5.

Links on status table shows empty search result because it doesn't generate right search fields from stat param.
index.php?function=visu_search&prov=stat&id_pack=XXX&stat=SUCCESS
index.php?function=visu_search&prov=stat&id_pack=XXX&stat=NOTIFIED
index.php?function=visu_search&prov=stat&id_pack=XXX&stat=*** All+the+errors ***

This patch fix broken deploy stats links and search.

## Related Issues
#540