### PR TITLE
table hover color

### DIFF
--- a/css/dataTables-custom.css
+++ b/css/dataTables-custom.css
@@ -37,7 +37,7 @@ table.dataTable.table-striped thead tr th {
 }
 
 .table-striped > tbody > tr:hover > td {
-    background-color: #f0f0f0;
+    background-color: #e2e2e2;
 }
 
 table.dataTable.cell-border tbody th,


### PR DESCRIPTION
## Status
**READY**

## Description
It's hard to see current row under the cursor because hover color is almost same.
This updates row hover color to a little darker.

Old hover color:
![hover_old](https://user-images.githubusercontent.com/9846054/44783883-24f54a80-ab62-11e8-98ba-6b770b9eaaa9.png)

New hover color:
![hover_new](https://user-images.githubusercontent.com/9846054/44783895-29216800-ab62-11e8-9916-8432ab684172.png)


## Impacted Areas in Application
* Tables in all computers, multisearch, etc.
