### PR TITLE
Fix Ipdiscover percent graph

### DIFF
--- a/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
+++ b/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
@@ -117,9 +117,7 @@ if (isset($protectedPost['DPT_CHOISE']) && $protectedPost['DPT_CHOISE'] != '0') 
         'NON_INVENTORIE' => 'NON_INVENTORIE',
         'IPDISCOVER' => 'IPDISCOVER',
         'IDENTIFIE' => 'IDENTIFIE');
-    if ($_SESSION['OCS']['profile']->getConfigValue('IPDISCOVER') == "YES") {
         $list_fields['PERCENT_BAR'] = 'pourcentage';
-    }
     $table_name = "IPDISCOVER";
     $tab_options['table_name'] = $table_name;
     $default_fields = $list_fields;

--- a/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
+++ b/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
@@ -80,7 +80,7 @@ if (isset($protectedPost['DPT_CHOISE']) && $protectedPost['DPT_CHOISE'] != '0') 
 					  non_ident.c as 'NON_INVENTORIE',
 					  ipdiscover.c as 'IPDISCOVER',
 					  ident.c as 'IDENTIFIE',
-					  CASE WHEN ident.c IS NULL and ipdiscover.c IS NULL THEN 100 WHEN non_ident.c IS NULL and ipdiscover.c IS NOT NULL THEN 100 WHEN ident.c IS NULL THEN round(inv.c * 100 / (non_ident.c + inv.c),1) ELSE round((inv.c + ident.c) * 100 / (non_ident.c + inv.c),1) END as 'pourcentage'
+					  round((ifnull(inv.c,0) + ifnull(ident.c,0)) * 100 / nullif(ifnull(inv.c,0) + ifnull(non_ident.c,0) + ifnull(ident.c,0), 0), 1) as 'pourcentage'
 			  from (SELECT COUNT(DISTINCT hardware_id) as c,'IPDISCOVER' as TYPE,tvalue as RSX
 					FROM devices
 					WHERE name='IPDISCOVER' and tvalue in  ";


### PR DESCRIPTION
## Status
**READY**

## Description
This fix broken ipdiscover percent graph.

Broken:
![ipdisc_broken_percent](https://user-images.githubusercontent.com/9846054/46470067-b41dff80-c7ab-11e8-85dc-a30f2b6ddaa0.png)


## Related Issues
#253

## Impacted Areas in Application
* ipdiscover
