### PR TITLE
Fix dateTimeFromMysql() dup time

### DIFF
--- a/plugins/language/br_BR/br_BR.txt
+++ b/plugins/language/br_BR/br_BR.txt
@@ -1126,7 +1126,7 @@
 1239 MHz
 1240 MB
 1241 Número de dispositivos SNMP
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Somente arquivos ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe e ocspackage.exe podem ser publicados
 1244 Esse arquivo não pode ser vazio
 1245 Administrar seus clientes OCS-NG

--- a/plugins/language/cs_CZ/cs_CZ.txt
+++ b/plugins/language/cs_CZ/cs_CZ.txt
@@ -1125,7 +1125,7 @@
 1239 MHz
 1240 MB
 1241 Počet SNMP zařízení
-1242 m/d/Y h:i
+1242 m/d/Y H:i
 1243 Poslat je možné pouze soubory ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe a ocspackage.exe
 1244 Tento soubor nemůže být prázdný
 1245 Spravovat OCS-NG klienty

--- a/plugins/language/de_DE/de_DE.txt
+++ b/plugins/language/de_DE/de_DE.txt
@@ -1200,7 +1200,7 @@
 1239 MHz
 1240 MB
 1241 Anzahl SNMP-Geräte
-1242 m/d/y h:i
+1242 m/d/y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 Diese Datei darf nicht leer sein.
 1245 OCS-NG-Clients verwalten

--- a/plugins/language/en_GB/en_GB.txt
+++ b/plugins/language/en_GB/en_GB.txt
@@ -1125,7 +1125,7 @@
 1239 MHz
 1240 MB
 1241 Number of SNMP devices
-1242 m/d/Y h:i
+1242 m/d/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/es_ES/es_ES.txt
+++ b/plugins/language/es_ES/es_ES.txt
@@ -1130,7 +1130,7 @@
 1239 MHz
 1240 MB
 1241 Number of SNMP devices
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/fr_FR/fr_FR.txt
+++ b/plugins/language/fr_FR/fr_FR.txt
@@ -1126,7 +1126,7 @@
 1239 MHz
 1240 Mo
 1241 Nombre de périphériques SNMP remontés
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Seuls les fichiers ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe et ocspackage.exe peuvent être envoyés
 1244 Le fichier ne peut pas être vide
 1245 Administrer les clients OCS-NG

--- a/plugins/language/it_IT/it_IT.txt
+++ b/plugins/language/it_IT/it_IT.txt
@@ -1126,7 +1126,7 @@
 1239 MHz
 1240 MB
 1241 Numero di periferiche SNMP
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 I soli file ammessi sono ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe ed ocspackage.exe
 1244 Questo file non può essere vuoto
 1245 Gestione client OCS-NG

--- a/plugins/language/ja_JP/ja_JP.txt
+++ b/plugins/language/ja_JP/ja_JP.txt
@@ -1125,7 +1125,7 @@
 1239 MHz
 1240 MB
 1241 SNMP対応デバイス数
-1242 Y/m/d h:i
+1242 Y/m/d H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/pl_PL/pl_PL.txt
+++ b/plugins/language/pl_PL/pl_PL.txt
@@ -1136,7 +1136,7 @@
 1239 MHz
 1240 MB
 1241 Liczba urządzeń SNMP
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Wysłać można tylko pliki: ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe i ocspackage.exe
 1244 Ten plik nie może być pusty
 1245 Zarządzaj klientami OCS-NG

--- a/plugins/language/pt_PT/pt_PT.txt
+++ b/plugins/language/pt_PT/pt_PT.txt
@@ -1205,7 +1205,7 @@
 1239 MHz
 1240 MB
 1241 Number of SNMP devices
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/ru_RU/ru_RU.txt
+++ b/plugins/language/ru_RU/ru_RU.txt
@@ -1125,7 +1125,7 @@
 1239 MHz
 1240 MB
 1241 Число устройств SNMP
-1242 д/м/Г ч:м
+1242 d/m/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 Это поле не может быть пусто
 1245 Manage your OCS-NG clients

--- a/plugins/language/si_SI/si_SI.txt
+++ b/plugins/language/si_SI/si_SI.txt
@@ -1130,7 +1130,7 @@
 1239 MHz
 1240 MB
 1241 Number of SNMP devices
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/tr_TR/tr_TR.txt
+++ b/plugins/language/tr_TR/tr_TR.txt
@@ -1125,7 +1125,7 @@
 1239 MHz
 1240 MB
 1241 Number of SNMP devices
-1242 d/m/Y h:i
+1242 d/m/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/ug_UY/ug_UY.txt
+++ b/plugins/language/ug_UY/ug_UY.txt
@@ -1221,7 +1221,7 @@
 1239 MHz
 1240 MB
 1241 Number of SNMP devices
-1242 Y/m/d h:i
+1242 Y/m/d H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Manage your OCS-NG clients

--- a/plugins/language/uk_UA/uk_UA.txt
+++ b/plugins/language/uk_UA/uk_UA.txt
@@ -1126,7 +1126,7 @@
 1239 МГц
 1240 МБ
 1241 Кількість пристроїв SNMP
-1242 m/d/Y h:i
+1242 m/d/Y H:i
 1243 Only ocsagent.exe, OCS-NG-Windows-Agent-Setup.exe and ocspackage.exe files can be post
 1244 This file can't be empty
 1245 Керуйте своїми клієнтами OCS-NG

--- a/require/function_commun.php
+++ b/require/function_commun.php
@@ -196,12 +196,8 @@ function addLog($type, $value = "", $lbl_sql = '') {
 
 function dateTimeFromMysql($v) {
     global $l;
-
-    $sql = "SELECT date_format('%s', '%s %%H:%%i:%%S') as dt";
-    $arg = array($v, $l->g(269));
-    $result = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"], $arg);
-    $ret = mysqli_fetch_array($result);
-    return $ret['dt'];
+    $d = DateTime::createFromFormat('Y-m-d H:i:s', $v);
+    return $d? $d->format($l->g(1242)) : '';
 }
 
 function reloadform_closeme($form = '', $close = false) {


### PR DESCRIPTION
## Status
**READY**

## Description
Computer details shows duplicated time in Last Inventory and Last Contact. 

![last time](https://user-images.githubusercontent.com/9846054/47379523-84d72000-d6d1-11e8-8507-18ed11c48514.png)

This commit:
* fix duplicated time output;
* updates function dateTimeFromMysql() to convert datetime without using mysql connection;
* update language id 1242 to display 24h time format.
