### PR TITLE
 First proof of concept of full-text searchable columns.

### DIFF
--- a/files/update/7022.sql
+++ b/files/update/7022.sql
@@ -1,0 +1,3 @@
+-- Create full text indexes for softwares name and publisher
+CREATE FULLTEXT INDEX publisher_ft_idx ON softwares (PUBLISHER);
+CREATE FULLTEXT INDEX name_ft_idx ON softwares (NAME);

--- a/plugins/main_sections/ms_all_soft/ms_all_soft.php
+++ b/plugins/main_sections/ms_all_soft/ms_all_soft.php
@@ -305,8 +305,10 @@ echo "</div>";
 echo "</div>";
 echo close_form();
 
-// Prevents searching in 'Count' columns
+// Prevents searching in some columns (Allows using full-text search by default)
 $tab_options['NO_SEARCH']['nb'] = 'nb';
+$tab_options['NO_SEARCH']['sc.CATEGORY_NAME'] = 'sc.CATEGORY_NAME';
+$tab_options['NO_SEARCH']['VERSION'] = 'VERSION';
 
 // Find out which visible columns are full-text indexed in the DB, and add this information to $tab_options
 $ft_idx = dbGetFTIndex('softwares', 's');

--- a/plugins/main_sections/ms_all_soft/ms_all_soft.php
+++ b/plugins/main_sections/ms_all_soft/ms_all_soft.php
@@ -308,6 +308,17 @@ echo close_form();
 // Prevents searching in 'Count' columns
 $tab_options['NO_SEARCH']['nb'] = 'nb';
 
+// Find out which visible columns are full-text indexed in the DB, and add this information to $tab_options
+$ft_idx = dbGetFTIndex('softwares', 's');
+foreach($tab_options['visible_col'] as $column) {
+        $cname = $tab_options['columns'][$column]['name'];
+        if (!empty($ft_idx[$cname])) {
+                $tab_options['columns'][$column]['ft_index'] = 'true';
+        } else {
+                $tab_options['columns'][$column]['ft_index'] = 'false';
+        }
+}
+
 if (AJAX) {
     ob_end_clean();
     tab_req($list_fields, $default_fields, $list_col_cant_del, $sql['SQL'], $tab_options);

--- a/require/function_commun.php
+++ b/require/function_commun.php
@@ -175,6 +175,24 @@ function dbconnect($server, $compte_base, $pswd_base, $db = DB_NAME) {
     return $link;
 }
 
+// Function to retrieve the columns that are full-text indexed within a table
+// Arguments:
+//   $tableName : The name of the SQL table to query
+//   $tableAlias: The alias of the SQL table in the query
+function dbGetFTIndex($tableName, $tableAlias) {
+
+     $ft_idx = [];
+     $sql_ft='show index from ' . $tableName . ';';
+     $resultDetails = mysql2_query_secure($sql_ft, $_SESSION['OCS']["readServer"]);
+     while($row = mysqli_fetch_object($resultDetails)){
+           if ( $row->Index_type == 'FULLTEXT') {
+                $ft_idx[ $row->Column_name ] = "$tableAlias.$row->Column_name";
+           }
+     }
+
+     return $ft_idx;
+}
+
 /* * *********************************END SQL FUNCTION***************************************** */
 
 function addLog($type, $value = "", $lbl_sql = '') {

--- a/require/function_table_html.php
+++ b/require/function_table_html.php
@@ -1468,12 +1468,20 @@ function ajaxfiltre($queryDetails,$tab_options){
                                 }
                                 $searchable =  ($tab_options['columns'][$column]['searchable'] == "true") ? true : false;
 
+				// Find out if the column is searchable and is full-text indexed
                                 if ($searchable && $tab_options['columns'][$column]['ft_index'] == 'true') {
-                                        // Column is searchable and is full-text indexed
-                                        if ($index==0) {
-                                                $ft_queryDetails1 .= " WHERE (MATCH ($cname) AGAINST ('$search')";
+                                        // Add a '+' in front of each word when $search contains several words
+                                        if (stripos($search, ' ') !== false) {
+                                                $search1 = '+'.implode(' +', explode(' ',$search));
+                                                error_log("SEARCH $search");
                                         } else {
-                                                $ft_queryDetails1 .= " OR MATCH ($cname) AGAINST ('$search')";
+                                                $search1 = $search;
+                                        }
+                                        // Append the search term
+                                        if ($index==0) {
+                                                $ft_queryDetails1 .= " WHERE (MATCH ($cname) AGAINST ('$search1' IN BOOLEAN MODE)";
+                                        } else {
+                                                $ft_queryDetails1 .= " OR MATCH ($cname) AGAINST ('$search1' IN BOOLEAN MODE)";
                                         }
                                         $index++;
                                 } elseif ($searchable && $tab_options['columns'][$column]['ft_index'] == 'false') {

--- a/require/function_table_html.php
+++ b/require/function_table_html.php
@@ -1470,12 +1470,13 @@ function ajaxfiltre($queryDetails,$tab_options){
 
 				// Find out if the column is searchable and is full-text indexed
                                 if ($searchable && $tab_options['columns'][$column]['ft_index'] == 'true') {
-                                        // Add a '+' in front of each word when $search contains several words
+                                        // Add a '+' in front of, and a '*' at the end of, each work  when $search contains several words
+                                        $search = trim($search);
                                         if (stripos($search, ' ') !== false) {
                                                 $search1 = '+'.implode(' +', explode(' ',$search));
-                                                error_log("SEARCH $search");
+                                                $search1  = implode(explode(' ',$search1),'* ')."*";
                                         } else {
-                                                $search1 = $search;
+                                                $search1 = $search . "*";
                                         }
                                         // Append the search term
                                         if ($index==0) {


### PR DESCRIPTION
## Status

**IN DEVELOPMENT**

## Description

Addendum:

1) The Full-text search doesn't work well yet. I think I need to tune how the fulltext index
is created or how the fulltext search is made
2) This PoC breaks the search functionality in the software table of a single agent.

===========================

First proof of concept of full-text searchable columns.

This PoC is able to do a full-text search when the user searches in the "All software" page
(visu_all_soft), while not breaking anything else AFAIK.

This PoC automatically detects when a column is full-text indexed and modify the search query
accordingly.

To create a full-text index against the "PUBLISHER" column in the "ocsweb.softwares" table,
 use the following command:

CREATE FULLTEXT INDEX publisher_ft_idx ON softwares (PUBLISHER);

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/663

## Todos
- [X] Tests
- [ ] Documentation

## Test environment
I'm testing on 2.6-RC on Ubuntu 18.04 and mysql

#### General informations
Operating system : Ubuntu 18.04 

#### Server informations
Php version :
Mysql / Mariadb / Percona version :
Apache version :

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, logical changes, etc.

1. Some additional FT_INDEX will need to be created in the DB

## Impacted Areas in Application
All "filtering of tables via AJAX" functions