### PR TITLE
Also group softwares by version in the "All softwares" view

### DIFF
--- a/plugins/main_sections/ms_all_soft/ms_all_soft.php
+++ b/plugins/main_sections/ms_all_soft/ms_all_soft.php
@@ -140,7 +140,7 @@ if($protectedPost['onglet'] == "ALL"){
     }
 
     if (isset($sql)) {
-        $sql['SQL'] .= " GROUP BY s.NAME";
+        $sql['SQL'] .= " GROUP BY s.NAME,s.VERSION";
         if ($sql_fin['SQL'] != '') {
             $sql['SQL'] .= $sql_fin['SQL'];
             $sql['ARG'] =  $sql_fin['ARG'];
@@ -188,7 +188,7 @@ elseif($protectedPost['onglet'] == "WITHOUT") {
 
     $sql['ARG'] = array($values['ivalue']['DEFAULT_CATEGORY']);
     if (isset($sql)) {
-        $sql['SQL'] .= " GROUP BY s.NAME";
+        $sql['SQL'] .= " GROUP BY s.NAME,s.VERSION";
         if ($sql_fin['SQL'] != '') {
             $sql['SQL'] .= $sql_fin['SQL'];
             $sql['ARG'] = $softCat->array_merge_values($sql['ARG'], $sql_fin['ARG']);
@@ -233,7 +233,7 @@ else {
 
     $sql['ARG'] = array($protectedPost['onglet']);
     if (isset($sql)) {
-        $sql['SQL'] .= " GROUP BY s.NAME";
+        $sql['SQL'] .= " GROUP BY s.NAME,s.VERSION";
         if ($sql_fin['SQL'] != '') {
             $sql['SQL'] .= $sql_fin['SQL'];
             $sql['ARG'] = $softCat->array_merge_values($sql['ARG'], $sql_fin['ARG']);


### PR DESCRIPTION
## Status
READY

## Description
This PR makes ocsreport groups softwares by name and version in the "All softwares" view (rather than by name only)

without this change:

![image](https://user-images.githubusercontent.com/8179031/54031569-67ea4780-41af-11e9-8b5b-350d7fe46a23.png)

with this change:

![image](https://user-images.githubusercontent.com/8179031/54031562-61f46680-41af-11e9-8af2-c5d29a38ed7f.png)


## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/700

## Todos
- [X] Tests
- [ ] Documentation

## Test environment
Test on my prod on 2.6-RC

I didn't test the change when software category is enabled though (so, I've only tested the change made around line 143)

#### General informations
Operating system : Ubuntu 18.04

#### Server informations
Php version :
Mysql / Mariadb / Percona version :
Apache version :

## Deploy Notes
NA
## Impacted Areas in Application
All softwares view