### PR TITLE
Filters the list of returned subnets in function 'find_all_subnet'

### DIFF
--- a/require/function_ipdiscover.php
+++ b/require/function_ipdiscover.php
@@ -255,10 +255,13 @@ function runCommand($command = "", $fname) {
     exec($command);
 }
 
+/* Returns all known subnets except those blacklisted */
 function find_all_subnet($dpt_choise = '') {
     if ($dpt_choise != '') {
-        return array_keys($_SESSION['OCS']["ipdiscover"][$dpt_choise]);
-    }
+        return array_filter(array_keys($_SESSION['OCS']["ipdiscover"][$dpt_choise]), function($k) {
+       		return ! (array_key_exists($k, $_SESSION['OCS']["ipdiscover"]["--Blacklist--"]));
+	});
+
     if (isset($_SESSION['OCS']["ipdiscover"])) {
         foreach ($_SESSION['OCS']["ipdiscover"] as $subnet) {
             foreach ($subnet as $sub => $poub) {


### PR DESCRIPTION
### Status
**READY**

### Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/764

### Addtional comments
In page "ipDiscover"', when selecting "-- Show all Subnets --", we get a table with all subnets, even the ones that we've blacklisted.

There's no need to list blacklisted subnets here as there's already another place where these can be found.
