### PR TITLE
Permit setting alternate mysql port in dbconfig

### DIFF
--- a/backend/require/connexion.php
+++ b/backend/require/connexion.php
@@ -42,7 +42,7 @@ function connexion_local_read() {
     $dbc->options(MYSQLI_INIT_COMMAND, "SET NAMES 'utf8'");
     $dbc->options(MYSQLI_INIT_COMMAND, "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
 
-    $link = mysqli_real_connect($dbc, SERVER_READ, COMPTE_BASE, PSWD_BASE, NULL, 3306, NULL, $connect);
+    $link = mysqli_real_connect($dbc, SERVER_READ, COMPTE_BASE, PSWD_BASE, NULL, SERVER_PORT, NULL, $connect);
 
     if($link) {
         $link_ocs = $dbc;
@@ -77,7 +77,7 @@ function connexion_local_write() {
     $dbc->options(MYSQLI_INIT_COMMAND, "SET NAMES 'utf8'");
     $dbc->options(MYSQLI_INIT_COMMAND, "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
 
-    $link = mysqli_real_connect($dbc, SERVER_READ, COMPTE_BASE, PSWD_BASE, NULL, 3306, NULL, $connect);
+    $link = mysqli_real_connect($dbc, SERVER_READ, COMPTE_BASE, PSWD_BASE, NULL, SERVER_PORT, NULL, $connect);
 
     if($link) {
         $link_ocs = $dbc;

--- a/crontab/cron_clean_cve.php
+++ b/crontab/cron_clean_cve.php
@@ -7,8 +7,8 @@ require_once('../require/cve/Cve.php');
 require_once('../require/config/include.php');
 require_once('../require/fichierConf.class.php');
 
-$_SESSION['OCS']["writeServer"] = dbconnect(SERVER_WRITE, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
-$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
+$_SESSION['OCS']["writeServer"] = dbconnect(SERVER_WRITE, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
+$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
 
 $cve = new Cve();
 

--- a/crontab/cron_cve.php
+++ b/crontab/cron_cve.php
@@ -7,8 +7,8 @@ require_once('../require/cve/Cve.php');
 require_once('../require/config/include.php');
 require_once('../require/fichierConf.class.php');
 
-$_SESSION['OCS']["writeServer"] = dbconnect(SERVER_WRITE, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
-$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
+$_SESSION['OCS']["writeServer"] = dbconnect(SERVER_WRITE, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
+$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
 
 $cve = new Cve();
 

--- a/crontab/cron_wol.php
+++ b/crontab/cron_wol.php
@@ -11,7 +11,7 @@ $wol_class = new Wol();
 
 $today = date('Y-m-d H:i');
 
-$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
+$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
 
 $sql = 'SELECT * FROM schedule_WOL';
 $result_wol = mysqli_query($_SESSION['OCS']["readServer"], $sql);

--- a/dbconfig.inc.php
+++ b/dbconfig.inc.php
@@ -24,6 +24,7 @@
 define("DB_NAME", "ocsweb");
 define("SERVER_READ","localhost");
 define("SERVER_WRITE","localhost");
+define("SERVER_PORT", 3306);
 define("COMPTE_BASE","ocs");
 define("PSWD_BASE","ocs");
 define("ENABLE_SSL","0");

--- a/plugins/main_sections/ms_plugins/functions_check.php
+++ b/plugins/main_sections/ms_plugins/functions_check.php
@@ -47,7 +47,7 @@ function install($archiveName) {
  */
 function check($plugarray) {
 
-    $conn = new PDO('mysql:host=' . SERVER_WRITE . ';dbname=' . DB_NAME . ';charset=utf8', COMPTE_BASE, PSWD_BASE);
+    $conn = new PDO('mysql:host=' . SERVER_WRITE . ';port=' . SERVER_PORT . ';dbname=' . DB_NAME . ';charset=utf8', COMPTE_BASE, PSWD_BASE);
 
     foreach ($plugarray as $value) {
 

--- a/require/function_commun.php
+++ b/require/function_commun.php
@@ -153,7 +153,7 @@ function prepare_sql_tab($list_fields, $explu = array(), $distinct = false) {
     return array('SQL' => substr($begin_sql, 0, -2) . " ", 'ARG' => $begin_arg);
 }
 
-function dbconnect($server, $compte_base, $pswd_base, $db = DB_NAME, $sslkey = SSL_KEY, $sslcert = SSL_CERT, $cacert = CA_CERT, $sslmode = SSL_MODE, $enablessl = ENABLE_SSL) {
+function dbconnect($server, $compte_base, $pswd_base, $db = DB_NAME, $sslkey = SSL_KEY, $sslcert = SSL_CERT, $cacert = CA_CERT, $sslmode = SSL_MODE, $enablessl = ENABLE_SSL, $port = 3306) {
     error_reporting(E_ALL & ~E_NOTICE);
     mysqli_report(MYSQLI_REPORT_STRICT);
     //$link is ok?
@@ -174,7 +174,7 @@ function dbconnect($server, $compte_base, $pswd_base, $db = DB_NAME, $sslkey = S
         $dbc->options(MYSQLI_INIT_COMMAND, "SET NAMES 'utf8'");
         $dbc->options(MYSQLI_INIT_COMMAND, "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
 
-        $link = mysqli_real_connect($dbc, $server, $compte_base, $pswd_base, NULL, 3306, NULL, $connect);
+        $link = mysqli_real_connect($dbc, $server, $compte_base, $pswd_base, NULL, $port, NULL, $connect);
 
         if($link) {
             $link = $dbc;

--- a/require/function_ipdiscover.php
+++ b/require/function_ipdiscover.php
@@ -251,7 +251,7 @@ function find_community_info($id) {
 }
 
 function runCommand($command = "", $fname) {
-    $command = "perl ipdiscover-util.pl $command -xml -h=" . SERVER_READ . " -u=" . COMPTE_BASE . " -p=" . PSWD_BASE . " -d=" . DB_NAME . " -path=" . $fname;
+    $command = "perl ipdiscover-util.pl $command -xml -h=" . SERVER_READ . " -P=" . SERVER_PORT . " -u=" . COMPTE_BASE . " -p=" . PSWD_BASE . " -d=" . DB_NAME . " -path=" . $fname;
     exec($command);
 }
 

--- a/require/header.php
+++ b/require/header.php
@@ -94,8 +94,8 @@ if (!defined("SERVER_READ") || !defined("DB_NAME") || !defined("SERVER_WRITE") |
 }
 
 //connect to databases
-$link_write = dbconnect(SERVER_WRITE, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
-$link_read = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
+$link_write = dbconnect(SERVER_WRITE, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
+$link_read = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
 //p($link_write);
 
 if (is_object($link_write) && is_object($link_read)) {

--- a/require/html_header.php
+++ b/require/html_header.php
@@ -153,7 +153,7 @@ if (isset($_SESSION['OCS']["loggeduser"]) && $_SESSION['OCS']['profile']->getCon
             $dbc->options(MYSQLI_INIT_COMMAND, "SET NAMES 'utf8'");
             $dbc->options(MYSQLI_INIT_COMMAND, "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
 
-            $link = mysqli_real_connect($dbc, SERVER_READ, DFT_DB_CMPT, DFT_DB_PSWD, NULL, 3306, NULL, $connect);
+            $link = mysqli_real_connect($dbc, SERVER_READ, DFT_DB_CMPT, DFT_DB_PSWD, NULL, SERVER_PORT, NULL, $connect);
 
             if($link) {
                 $link = $dbc;

--- a/tools/cron_mailer.php
+++ b/tools/cron_mailer.php
@@ -8,7 +8,7 @@ require_once('../require/config/include.php');
 require_once('../require/fichierConf.class.php');
 
 
-$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT);
+$_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, DB_NAME, SSL_KEY, SSL_CERT, CA_CERT, SERVER_PORT);
 $mail = new NotificationMail(DEFAULT_LANGUAGE);
 
 $week = array('MON' => 'Monday', 'TUE' => 'Tuesday', 'WED' => 'Wednesday', 'THURS' => 'Thursday', 'FRI' => 'Friday', 'SAT' => 'Saturday', 'SUN' => 'Sunday');


### PR DESCRIPTION
### Status
**READY**

### Related Issues
Put here all the related issues link:
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/818

### Documentation
The documentation may want to include instructions on how to set `SERVER_PORT` in the dbconf for non standard mysql ports.

### Additional comments
This is a minimal change to permit using ocsreports with a mysql server on an alternate port.  It does not fix up install.php and instead targets entry points as needed.
