### PR TITLE
Permit loading a local config with additional settings if it exists

### DIFF
--- a/var.php
+++ b/var.php
@@ -154,4 +154,10 @@ define('DFT_DB_CMPT', 'ocs');
 define('DFT_DB_PSWD', 'ocs');
 define('DFT_GUI_CMPT', 'admin');
 define('DFT_GUI_PSWD', 'admin');
+
+//====================================================================================
+// Load localconfig.inc.php if it exists
+//====================================================================================
+if (file_exists(ETC_DIR . '/localconfig.inc.php')))
+    include(ETC_DIR . '/localconfig.inc.php');
 ?>


### PR DESCRIPTION
### Status
**READY**

### Related Issues
None

### Documentation
This permits creating a local config file with additional settings to be included if it exists.

### Additional comments
For setting up additional plugins or php settings, it is helpful to have a place to load settings that is controlled by the system admin.  This permits the admin to create a local config file that will be loaded.
