### PR TITLE
reverted to initial behaviour still supporting ssl mode for SQL

### DIFF
--- a/require/html_header.php
+++ b/require/html_header.php
@@ -153,7 +153,7 @@ if (isset($_SESSION['OCS']["loggeduser"]) && $_SESSION['OCS']['profile']->getCon
             $dbc->options(MYSQLI_INIT_COMMAND, "SET NAMES 'utf8'");
             $dbc->options(MYSQLI_INIT_COMMAND, "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
 
-            $link = mysqli_real_connect($dbc, SERVER_READ, COMPTE_BASE, PSWD_BASE, NULL, 3306, NULL, $connect);
+            $link = mysqli_real_connect($dbc, SERVER_READ, DFT_DB_CMPT, DFT_DB_PSWD, NULL, 3306, NULL, $connect);
 
             if($link) {
                 $link = $dbc;


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

### Status
**READY

### Related Issues
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/879

### Documentation
In the case, your pull request need the documentation to be modified, please say it here.
You can also directly create a pull request for the documentation here : https://github.com/OCSInventory-NG/Wiki

Note : Merge process will be faster is the documentation is already written

### Addtional comments
Reverted code to initial behaviour.
This patch will removed the error message when not using default ocs database credentials.