### PR TITLE
Fixing deployment issue #944 

### DIFF
--- a/plugins/main_sections/ms_teledeploy/ms_tele_package.php
+++ b/plugins/main_sections/ms_teledeploy/ms_tele_package.php
@@ -289,6 +289,7 @@ if (isset($protectedPost['valid'])) {
         if ($protectedPost['REDISTRIB_USE'] == 1) {
             echo "<br />";
             echo "<h4>" . $l->g(1003) . "</h4>";
+            javascript_pack();
             input_pack_taille("tailleFrag_redistrib", "nbfrags_redistrib", round($size), '8', round($size / 1024), $l->g(463), $l->g(516));
             input_pack_taille("nbfrags_redistrib", "tailleFrag_redistrib", round($size), '5', '1', $l->g(464), '<span class="glyphicon glyphicon-th-large"></span>');
             $java_script = "verif_redistributor();";

--- a/require/function_telediff.php
+++ b/require/function_telediff.php
@@ -83,19 +83,18 @@ function time_deploy($label = '') {
 }
 
 function input_pack_taille($name, $other_field, $size, $input_size, $input_value, $label = '', $addon = '', $modif = true) {
-    javascript_pack();
     if ($size > 1024 && $modif == true) {
-        $champ = '	onKeyPress="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
-		 			onkeydown="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
-		 			onkeyup="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
-		  			onblur="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
-		  			onclick="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
-				';
+        $champ = ' onKeyPress="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
+                   onkeydown="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
+                   onkeyup="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
+                   onblur="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
+                   onclick="maj(\'' . $name . '\', \'' . $other_field . '\', \'' . $size . '\');"
+                   ';
     } elseif($modif == false) {
-        $champ = " disabled='disabled' ";
+        $champ = " style='pointer-events:none; background:lightgrey;' ";
     } else {
-		$champ = " value=1 disabled='disabled' ";
-	}
+        $champ = " style='pointer-events:none; background:lightgrey;' ";
+    }
     formGroup('text', $name, $label, $input_size, '', $input_value, '', '', '', $champ, ($addon != '' ? $addon : ''));
 }
 


### PR DESCRIPTION
### Status
READY

### Related Issues
#944  Small files can not be deployed (zip<=1024 bytes)

### Documentation
No documentation amendment required.

### The issue solved by this change:
At software deployment, package builder, small files are not handled correctly which results with a failure in deployment.

Steps to reproduce:
Go to software deployment, Build. Upload a zip which is smaller than 1025 bytes. Hit send.

On the next page you will see Fragments size and Fragments number greyed out. As the size is very small this is fine, it does not make any sense to fragment a zip which is this small.

You can follow the procedure to create the deployment and deploy it to any computers.

The deployment will fail, the agent will download only the info file but not the zip.

I searched and found why is this happening. In the info file, the number of fragments is incorrect, instead of 1 it is set to 0.

This happens because in the second form of the build process the nb_frags field is set to disabled. The intent here was probably not to allow to fragment the file, but this does not only disable the user interaction of this field, but also it will not be submitted.

Additionally I cleaned up a bit, download time calculator Javascript now included only once.
