### PR TITLE
PR #765 broke blacklist subnet list

### DIFF
--- a/require/function_ipdiscover.php
+++ b/require/function_ipdiscover.php
@@ -255,14 +255,10 @@ function runCommand($command = "", $fname) {
     exec($command);
 }
 
-/* Returns all known subnets except those blacklisted */
 function find_all_subnet($dpt_choise = '') {
     if ($dpt_choise != '') {
-        return array_filter(array_keys($_SESSION['OCS']["ipdiscover"][$dpt_choise]), function($k) {
-       		return ! (array_key_exists($k, $_SESSION['OCS']["ipdiscover"]["--Blacklist--"]));
-        });
+        return array_keys($_SESSION['OCS']["ipdiscover"][$dpt_choise]);
     }
-
     if (isset($_SESSION['OCS']["ipdiscover"])) {
         foreach ($_SESSION['OCS']["ipdiscover"] as $subnet) {
             foreach ($subnet as $sub => $poub) {


### PR DESCRIPTION
The patch on PR #765 is broken.
https://github.com/OCSInventory-NG/OCSInventory-ocsreports/pull/765 commit cb7695677d054d9d2328f22cfe635cbde10cbd65

With english language it filters out blacklist subnet list,
now blacklisted subnets doesn't appear anymore when `--Blacklist--` is selected in
`ocsreports/index.php?function=show_ipdiscover`.

With non english language it causes:
`Warning: array_key_exists() expects parameter 2 to be array, null given in ocsreports/require/function_ipdiscover.php on line 262`

All subnets and Blacklist list was already working correctly.

Look at the file `ocsreports/backend/ipdiscover/methode/local.php` with Extra comments.
```
while ($row = mysqli_fetch_object($res)) {
    unset($id);
    $list_subnet[] = $row->ipsubnet;
    /* ... */
    if (is_array($subnetToBlacklist)) {
        foreach ($subnetToBlacklist as $key => $value) {
            if ($key == $row->ipsubnet) {
                $id = '--' . $l->g(703) . '--'; // ****** blacklist
            }
        }
    }

    //this subnet was identify
    // ****** has id   and   it's NOT Blacklisted
    if ($row->id != null && !isset($id)) { 
        // ****** add to it's own id
        $list_ip[$row->id][$row->ipsubnet] = $row->name;
        // ****** add to all subnets
        $list_ip['---' . $l->g(1138) . '---'][$row->ipsubnet] = $row->name;

    // ****** it's NOT Blacklisted
    } elseif (!isset($id)) { 
        // ****** add to unknown subnets
        $no_name = '---' . $l->g(885) . '---';
        $list_ip[$no_name][$row->ipsubnet] = $no_name;
        // ****** add to all subnets
        $list_ip['---' . $l->g(1138) . '---'][$row->ipsubnet] = $no_name;

    } else { 
        // ****** add to blacklist
        $list_ip[$id][$row->ipsubnet] = $id;
    }
}
```

This pull request revert the broken commit cb7695677d054d9d2328f22cfe635cbde10cbd65.
