### PR TITLE
restore deploy Launch option

### DIFF
--- a/plugins/language/en_GB/en_GB.txt
+++ b/plugins/language/en_GB/en_GB.txt
@@ -348,7 +348,7 @@
 453 Installation completion need user action
 454 NO
 455 YES
-456 Execute / Launch
+456 Execute
 457 Store
 458 Launch
 459 Countdown must be a number

--- a/plugins/language/fr_FR/fr_FR.txt
+++ b/plugins/language/fr_FR/fr_FR.txt
@@ -348,7 +348,7 @@
 453 La fin de l'installation nécessite une intervention utilisateur
 454 NON
 455 OUI
-456 Exécuter / Lancer
+456 Exécuter
 457 Stocker
 458 Lancer
 459 Le compte à rebours doit être un nombre

--- a/plugins/main_sections/ms_teledeploy/ms_tele_package.php
+++ b/plugins/main_sections/ms_teledeploy/ms_tele_package.php
@@ -730,6 +730,7 @@ $yes_no = array("0", "1");
 $list_action = [
 	"EXECUTE" => $l->g(456),
 	"STORE" => $l->g(457),
+	"LAUNCH" => $l->g(458)
 ];
 
 $arrayDisplayValue = [
@@ -743,6 +744,7 @@ $arrayDisplayValue = array(
     "ACTION" => array(
         "EXECUTE" => $l->g(456),
         "STORE" => $l->g(457),
+        "LAUNCH" => $l->g(458)
     ),
     "yes_no" => array(
         "0" => $l->g(454),

--- a/plugins/main_sections/ms_teledeploy/views/package_form_view.php
+++ b/plugins/main_sections/ms_teledeploy/views/package_form_view.php
@@ -136,6 +136,7 @@ function show_basic_info_frame($data, $errors) {
         'options' => array(
             'STORE' => $l->g(457),
             'EXECUTE' => $l->g(456),
+            'LAUNCH' => $l->g(458)
         ),
     ));
 


### PR DESCRIPTION
The deploy **Launch** option was been removed by commit 3919527f57a9dab7e3b35dd41f822f4f0a694e57 on PR #849.

But **Execute** and **Launch** options is not the same.

The **Launch** option "launch" the file inside the zip file and wait all child process end, this is required for some installers work correctly. On linux launch option is required to "launch" the file and get it's exit code.

This PR revert removal of launch option.

If one option may be removed, I think it's the "Execute" option.
And keep the **Launch** option because it's needed for deploy to work correcly on both Windows and Linux.


`WindowsAgent/Download/Package.cpp`:
```
if (m_csAction == OCS_DOWNLOAD_ACTION_LAUNCH)
{
  // ...
  // Execute command and wait for all childs to terminate
  switch (cmProcess.execWaitForAllChilds( m_csCommand, m_csPath))
  // ...
}
if (m_csAction == OCS_DOWNLOAD_ACTION_EXECUTE)
{
  // ...
  // Execute command and wait only for main process to terminate
  switch (cmProcess.execWait( m_csCommand, m_csPath))
  // ...
}
```

`UnixAgent/lib/Ocsinventory/Agent/Modules/Download.pm`:
```
if ($packages->{$id}->{'ACT'} eq 'LAUNCH'){
  // ...
  # Exec specified file (LAUNCH => NAME)
  if (-e $packages->{$id}->{'NAME'}){
    $logger->debug("Launching $packages->{$id}->{'NAME'}...");
    chmod(0755, $packages->{$id}->{'NAME'}) or die("Cannot chmod: $!");
    $exit_code = system( "./".$exe_line ) >> 8;
  }
  // ...
} elsif ($packages->{$id}->{'ACT'} eq 'EXECUTE'){
  # Exec specified command EXECUTE => COMMAND
  $logger->debug("Execute $packages->{$id}->{'COMMAND'}...");
  system( $packages->{$id}->{'COMMAND'} ) and die();
}
```
