### PR TITLE
Migrate softwares table

### DIFF
--- a/files/update/7030.sql
+++ b/files/update/7030.sql
@@ -1,5 +1,3 @@
--- Drop the old software table
-DROP TABLE `softwares`;
 
 -- Create software_name table
 CREATE TABLE IF NOT EXISTS `software_name` (

--- a/files/update/7037.sql
+++ b/files/update/7037.sql
@@ -1,0 +1,42 @@
+
+-- migrate software name
+INSERT IGNORE INTO `software_name` (`NAME`)
+SELECT DISTINCT `NAME`
+FROM `softwares`;
+
+-- migrate software publisher
+INSERT IGNORE INTO `software_publisher` (`PUBLISHER`)
+SELECT DISTINCT `PUBLISHER`
+FROM `softwares`;
+
+-- migrate software version
+INSERT IGNORE INTO `software_version` (`VERSION`)
+SELECT DISTINCT `VERSION`
+FROM `softwares`;
+
+-- migrate softwares
+INSERT IGNORE INTO `software` (
+  `ID`, `HARDWARE_ID`, `NAME_ID`, `PUBLISHER_ID`, `VERSION_ID`,
+  `FOLDER`, `COMMENTS`, `FILENAME`, `FILESIZE`,
+  `SOURCE`, `GUID`, `LANGUAGE`, `INSTALLDATE`, `BITSWIDTH`)
+SELECT s.`ID`, s.`HARDWARE_ID`, n.`ID`, p.`ID`, v.`ID`,
+  s.`FOLDER`, s.`COMMENTS`, s.`FILENAME`, s.`FILESIZE`,
+  s.`SOURCE`, s.`GUID`, s.`LANGUAGE`, s.`INSTALLDATE`, s.`BITSWIDTH`
+FROM `softwares` s
+INNER JOIN `software_name` n ON (n.`NAME` = s.`NAME`)
+INNER JOIN `software_publisher` p ON (p.`PUBLISHER` = s.`PUBLISHER`)
+INNER JOIN `software_version` v ON (v.`VERSION` = s.`VERSION`);
+
+-- add missing indexes
+ALTER TABLE `software` ADD KEY `NAME_ID` (`NAME_ID`);
+ALTER TABLE `software` ADD KEY `PUBLISHER_ID` (`PUBLISHER_ID`);
+ALTER TABLE `software` ADD KEY `VERSION_ID` (`VERSION_ID`);
+
+-- drop old softwares
+DROP TABLE `softwares`;
+
+
+-- add missing primary keys
+ALTER TABLE `deleted_equiv` ADD `ID` INT NOT NULL AUTO_INCREMENT FIRST, ADD PRIMARY KEY (`ID`);
+ALTER TABLE `devices` ADD `ID` INT NOT NULL AUTO_INCREMENT FIRST, ADD PRIMARY KEY (`ID`);
+

--- a/var.php
+++ b/var.php
@@ -69,7 +69,7 @@ define('TEMPLATE', __DIR__.'/templates/');
 /**
  * OCS' MySQL database version
  */
-define('GUI_VER', '7036');
+define('GUI_VER', '7037');
 /**
  * GUI Version
  */


### PR DESCRIPTION
This is a improvement for software table rework done at PR #942 .

Instead of just drop old `softwares` table and loose data, we can migrate it to the new tables.

What this PR does is:
* Remove line `drop table softwares` from update `7030.sql`, so we can migrate it if it's not already dropped.
* Add a new update: `7037.sql` to migrate `softwares` table contents to:
 `software`, `software_name`, `software_publisher`, `software_version`.
* Add some missing indexes and primary keys.

Insert into software from old softwares table may take a while if it's too big.
