### PR TITLE
Fix deploy small packages

### DIFF
--- a/require/function_telediff.php
+++ b/require/function_telediff.php
@@ -416,6 +416,7 @@ function create_pack($sql_details, $info_details, $modif = "true") {
         if ($size = @filesize($fname)) {
             $handle = fopen($fname, "rb");
             $read = 0;
+            if(!isset($sql_details['nbfrags'])) $sql_details['nbfrags'] = 1;
             for ($i = 1; $i < $sql_details['nbfrags']; $i++) {
                 $contents = fread($handle, $size / $sql_details['nbfrags']);
                 $read += strlen($contents);


### PR DESCRIPTION
The fix pr #774 for #743 broke #662.
Now small packages is beign built with `<DOWNLOAD ... FRAGS="0"` and cause deploy of small packages to fail.

This pull-request fix it setting frags=1 when it has a frag file and nbfrags is not set.
