### PR TITLE
Fix #961

### DIFF
--- a/plugins/main_sections/ms_computer/ms_computer_views.php
+++ b/plugins/main_sections/ms_computer/ms_computer_views.php
@@ -69,7 +69,7 @@ function show_computer_actions($computer){
     echo '</h3>';
     echo "&nbsp;&nbsp;";
 
-    if ($_SESSION['OCS']['profile']->getRestriction('WOL', 'NO') == "NO") {
+    if ($_SESSION['OCS']['profile']->getRestriction('WOL', 'NO') == "NO" && isset($protectedGet['cat']) && $protectedGet['cat'] == 'admin') {
         echo "<button class='btn btn-action' OnClick='confirme(\"\",\"WOL\",\"bandeau\",\"WOL\",\"" . $l->g(1283) . "\");'>WOL</button> ";
     }
     echo "</div>";


### PR DESCRIPTION
Display WOL button only on admin tab because WOL function works only on admin tab

https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/d187a6938224c31f2b921df4ee7ad312b67b89ff/plugins/main_sections/ms_computer/ms_computer.php#L82

and  `echo "<input type='hidden' id='WOL' name='WOL' value=''>";` is not displayed in others tab

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

### Status
IN DEVELOPMENT
### Related Issues
#961 

### Addtional comments
Display button WOL only on admin tab because show_computer_summary($item); function is only call in the case of admin tab
