### PR TITLE
fix ipdiscover subnet list

### DIFF
--- a/require/ipdiscover/Ipdiscover.php
+++ b/require/ipdiscover/Ipdiscover.php
@@ -300,12 +300,9 @@ class Ipdiscover
 		exec($command);
 	}
 
-	/* Returns all known subnets except those blacklisted */
 	public function find_all_subnet($dpt_choise = '') {
 		if ($dpt_choise != '') {
-			return array_filter(array_keys($_SESSION['OCS']["ipdiscover"][$dpt_choise]), function($k) {
-				return !(array_key_exists($k, $_SESSION['OCS']["ipdiscover"]["--Blacklist--"]));
-			});
+			return array_keys($_SESSION['OCS']["ipdiscover"][$dpt_choise]);
 		}
 
 		if (isset($_SESSION['OCS']["ipdiscover"])) {


### PR DESCRIPTION
### Status
**READY**

### Bug
With ocsreports 2.8 when using english language, blacklisted subnets doesn't appear anymore when `--Blacklist--` is selected in
`ocsreports/index.php?function=show_ipdiscover`.

When using non english language happens a warning:
`PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in require/ipdiscover/Ipdiscover.php on line 307`

### Description
This Fix is a reaply of #1009 because in the new version 2.8 functions was moved from file `require/function_ipdiscover.php` to `require/ipdiscover/Ipdiscover.php` without the fix.
