### PR TITLE
delete locks unix_timestamp optimization

### DIFF
--- a/require/function_computers.php
+++ b/require/function_computers.php
@@ -26,7 +26,7 @@
  * @param id Hardware identifier to be locked
  */
 function lock($id) {
-    $reqClean = "DELETE FROM locks WHERE unix_timestamp(since)<(unix_timestamp(NOW())-3600)";
+    $reqClean = "DELETE FROM locks WHERE since<(date_sub(NOW(), interval 3600 second))";
     mysql2_query_secure($reqClean, $_SESSION['OCS']["writeServer"]);
 
     $reqLock = "INSERT INTO locks(hardware_id) VALUES ('%s')";


### PR DESCRIPTION
### Status
**READY**

### Description

This is a optimization to speed up sql query `delete from locks`.
It wasn't using indexes because of function `unix_timestamp(since)`.
Noticed it because we have a busy server with 35k alive machines.

**Before:** full table scan (type all, key null)
```
MariaDB [ocsweb]> explain DELETE FROM locks WHERE unix_timestamp(since)<(unix_timestamp(NOW())-3600);
+------+-------------+-------+------+---------------+------+---------+------+------+-------------+
| id   | select_type | table | type | possible_keys | key  | key_len | ref  | rows | Extra       |
+------+-------------+-------+------+---------------+------+---------+------+------+-------------+
|    1 | SIMPLE      | locks | ALL  | NULL          | NULL | NULL    | NULL |  258 | Using where |
+------+-------------+-------+------+---------------+------+---------+------+------+-------------+
```

**After:** use index (type range, key since)
```
MariaDB [ocsweb]> explain DELETE FROM locks WHERE since<(date_sub(NOW(), interval 3600 second));
+------+-------------+-------+-------+---------------+-------+---------+------+------+-------------+
| id   | select_type | table | type  | possible_keys | key   | key_len | ref  | rows | Extra       |
+------+-------------+-------+-------+---------------+-------+---------+------+------+-------------+
|    1 | SIMPLE      | locks | range | SINCE         | SINCE | 4       | NULL |    1 | Using where |
+------+-------------+-------+-------+---------------+-------+---------+------+------+-------------+
```
