### PR TITLE
Fix tag showing when ipdiscover is not linked to tag

### DIFF
--- a/plugins/main_sections/ms_ipdiscover/ms_admin_ipdiscover.php
+++ b/plugins/main_sections/ms_ipdiscover/ms_admin_ipdiscover.php
@@ -73,6 +73,7 @@ if ($protectedPost['onglet'] == 'ADMIN_RSX') {
     $url_show_ipdiscover = 'index.php?function=show_ipdiscover';
 
     if (!$method) {
+
         if (is_defined($protectedPost['SUP_PROF'])) {
             $ipdiscover->delete_subnet($protectedPost['SUP_PROF']);
             $tab_options['CACHE'] = 'RESET';
@@ -147,6 +148,8 @@ if ($protectedPost['onglet'] == 'ADMIN_RSX') {
                 $list_subnet = array();
             }
 
+            $is_tag_linked = look_config_default_values('IPDISCOVER_LINK_TAG_NETWORK');
+
             $list_subnet = array(0 => "") + $list_subnet;
 
             $list_tag = $ipdiscover->get_tag();
@@ -159,7 +162,7 @@ if ($protectedPost['onglet'] == 'ADMIN_RSX') {
                 'ADD_SX_RSX' => $protectedPost['ADD_SX_RSX']
             );
 
-            $ipdiscover->form_add_subnet($title, $default_values, $form_name);
+            $ipdiscover->form_add_subnet($title, $default_values, $form_name, $is_tag_linked['ivalue']['IPDISCOVER_LINK_TAG_NETWORK']);
         } else {
             $sql = "SELECT NETID, NAME, ID, MASK, TAG, CONCAT(NETID,IFNULL(TAG, '')) as supsub FROM subnet";
 

--- a/require/ipdiscover/Ipdiscover.php
+++ b/require/ipdiscover/Ipdiscover.php
@@ -63,10 +63,15 @@ class Ipdiscover
 		return $row;
 	}
 
-	public function form_add_subnet($title = '', $default_value, $form) {
+	public function form_add_subnet($title = '', $default_value, $form, $is_tag_linked) {
 		global $l, $pages_refs;
 	
-		$name_field = array("RSX_NAME", "ID_NAME", "ADD_TAG", "ADD_IP", "ADD_SX_RSX");
+		if($is_tag_linked){
+			$name_field = array("RSX_NAME", "ID_NAME", "ADD_TAG", "ADD_IP", "ADD_SX_RSX");
+		}else{
+			$name_field = array("RSX_NAME", "ID_NAME", "ADD_IP", "ADD_SX_RSX");
+		}
+		
 
 		if (isset($_SESSION['OCS']["ipdiscover_id"])) {
 			$lbl_id = $_SESSION['OCS']["ipdiscover_id"];
@@ -74,15 +79,33 @@ class Ipdiscover
 			$lbl_id = $l->g(305) . ":";
 		}
 
-		$tab_name = array($l->g(304) . " :", $lbl_id . " :", "TAG :", $l->g(34) . " :", $l->g(208) . " :");
+		if($is_tag_linked){
+			$tab_name = array($l->g(304) . " :", $lbl_id . " :", "TAG :", $l->g(34) . " :", $l->g(208) . " :");
+		}else{
+			$tab_name = array($l->g(304) . " :", $lbl_id . " :", $l->g(34) . " :", $l->g(208) . " :");
+		}
+		
 
-		if ($title == $l->g(931)) {
-			$type_field = array(0, 2, 2, 13, 0);
-		} else {
-			$type_field = array(0, 2, 2, 0, 0);
+		if($is_tag_linked){
+			if ($title == $l->g(931)) {
+				$type_field = array(0, 2, 2, 13, 0);
+			} else {
+				$type_field = array(0, 2, 2, 0, 0);
+			}
+		}else{
+			if ($title == $l->g(931)) {
+				$type_field = array(0, 2, 13, 0);
+			} else {
+				$type_field = array(0, 2, 0, 0);
+			}
 		}
 	
-		$value_field = array($default_value['RSX_NAME'], $default_value['ID_NAME'], $default_value['ADD_TAG'], $default_value['ADD_IP'], $default_value['ADD_SX_RSX']);
+		if($is_tag_linked){
+			$value_field = array($default_value['RSX_NAME'], $default_value['ID_NAME'], $default_value['ADD_TAG'], $default_value['ADD_IP'], $default_value['ADD_SX_RSX']);
+		}else{
+			$value_field = array($default_value['RSX_NAME'], $default_value['ID_NAME'], $default_value['ADD_IP'], $default_value['ADD_SX_RSX']);
+		}
+		
 	
 		$tab_typ_champ = show_field($name_field, $type_field, $value_field);
 


### PR DESCRIPTION
### Status
**READY** (remove the irrevelant words)

### Description
TAG form field was showing even if IpDiscover link on tag was disabled.


