### PR TITLE
fix search hardware name or name

### DIFF
--- a/require/search/Search.php
+++ b/require/search/Search.php
@@ -485,8 +485,7 @@
                       global $l;
                       $this->queryArgs[] = $l->g(269);
                     } else {
-                      $this->columnsQueryConditions .= "$operator[$p] $open EXISTS (SELECT 1 FROM %s WHERE %s.%s %s '%s')$close ";
-                      $this->queryArgs[] = $nameTable;
+                      $this->columnsQueryConditions .= "$operator[$p] $open(%s.%s %s '%s')$close ";
                       $this->queryArgs[] = $nameTable;
                       $this->queryArgs[] = $value[self::SESS_FIELDS];
                       $this->queryArgs[] = $value[self::SESS_OPERATOR];


### PR DESCRIPTION
### Status
**READY**

### Description
MultiSearch with criteria (hostname OR hostname) returns all computers instead of search criteria.

It generates a sql `from hardware` with no reference to `exists from hardware`
because `WHERE hardware.NAME` use it's own local `from hardware`.

Current sql:
```
SELECT hardware.ID AS hardwareID , [...]
FROM hardware 
INNER JOIN accountinfo on hardware.id = accountinfo.hardware_id 
WHERE (
  EXISTS (SELECT 1 FROM hardware WHERE hardware.NAME = 'pc01') OR  
  EXISTS (SELECT 1 FROM hardware WHERE hardware.NAME = 'pc02')
  ) 
  AND accountinfo.TAG IN ([...]) 
GROUP BY hardware.id
```

This commit fix sql:
```
SELECT hardware.ID AS hardwareID , [...]
FROM hardware 
INNER JOIN accountinfo on hardware.id = accountinfo.hardware_id 
WHERE ((hardware.NAME = 'pc01') OR (hardware.NAME = 'pc02'))  
  AND accountinfo.TAG IN ([...]) 
GROUP BY hardware.id
```
