### PR TITLE
Make $protectedGet available, otherwise the WOL button won't show

### DIFF
--- a/plugins/main_sections/ms_computer/ms_computer_views.php
+++ b/plugins/main_sections/ms_computer/ms_computer_views.php
@@ -57,6 +57,7 @@ function show_computer_title($computer) {
 }
 
 function show_computer_actions($computer){
+    global $protectedGet;
     global $l;
 
     $urls = $_SESSION['OCS']['url_service'];


### PR DESCRIPTION
### Status
**READY**

### Description
Fix #961 was imcomplete, as the WOL button would never show up. This fixes this by making $protectedGet available.

