### PR TITLE
mysqli warnings during install.php

### DIFF
--- a/require/function_commun.php
+++ b/require/function_commun.php
@@ -342,8 +342,9 @@ function msg_error($txt, $close = false) {
 }
 
 function html_header($noJavascript = false) {
-
-    $value_theme = look_config_default_values('CUSTOM_THEME');
+    if (!$_SESSION['OCS']['readServer']) {
+        $value_theme = look_config_default_values('CUSTOM_THEME');
+    }
     if(is_null($value_theme)){
       $value_theme['tvalue']['CUSTOM_THEME'] = DEFAULT_THEME;
     }


### PR DESCRIPTION
### Status
**READY** (remove the irrevelant words)

### Description
not looking for default config value if server cannot be read should avoid mysqli warnings



