### PR TITLE
fix error msg when install extension alread installed

### DIFF
--- a/plugins/main_sections/ms_extensionmanager/ms_extensionmanager.php
+++ b/plugins/main_sections/ms_extensionmanager/ms_extensionmanager.php
@@ -86,7 +86,7 @@ if($extMgr->checkPrerequisites()){
 if (!AJAX) {
     if(isset($protectedPost['extensions'])){
         $result = $extMgr->installExtension($protectedPost['extensions']);
-        if($result == true) {
+        if($result === true) {
             msg_success($l->g(7017));
         } elseif($result == 'isInstalled') {
             msg_error($l->g(7018));

--- a/require/extensions/ExtensionManager.php
+++ b/require/extensions/ExtensionManager.php
@@ -164,7 +164,7 @@ class ExtensionManager{
 
         if($this->isInstalled($name)){
             // TODO : error already installed
-            return false;
+            return 'isInstalled';
         }
 
         // Add plugin record in database


### PR DESCRIPTION
### Status
**READY** 

### Description
Hi, first pull request i do here!
When you try to install an already installed extension from web interface you get this generic message:
_A PHP error occurred._

After trying to find the error i decided to look into php code and found out it i already had installed the extension
AND there is already the message `7018`:
_This extension is already installed._
and almost everything in place but the message does not kick in because `installExtension` returns false instead of 'isInstalled' in this case.
Small fix that worked on my ocs instance


