### PR TITLE
Fix software id column

### DIFF
--- a/files/ocsbase.sql
+++ b/files/ocsbase.sql
@@ -2196,7 +2196,7 @@ DROP TABLE IF EXISTS `software`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software` (
-  `ID` int NOT NULL AUTO_INCREMENT,
+  `ID` bigint NOT NULL AUTO_INCREMENT,
   `HARDWARE_ID` int NOT NULL,
   `NAME_ID` int NOT NULL,
   `PUBLISHER_ID` int NOT NULL,

--- a/files/ocsbase_new.sql
+++ b/files/ocsbase_new.sql
@@ -2196,7 +2196,7 @@ DROP TABLE IF EXISTS `software`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software` (
-  `ID` int NOT NULL AUTO_INCREMENT,
+  `ID` bingint NOT NULL AUTO_INCREMENT,
   `HARDWARE_ID` int NOT NULL,
   `NAME_ID` int NOT NULL,
   `PUBLISHER_ID` int NOT NULL,

--- a/files/ocsbase_new.sql
+++ b/files/ocsbase_new.sql
@@ -2196,7 +2196,7 @@ DROP TABLE IF EXISTS `software`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `software` (
-  `ID` bingint NOT NULL AUTO_INCREMENT,
+  `ID` bigint NOT NULL AUTO_INCREMENT,
   `HARDWARE_ID` int NOT NULL,
   `NAME_ID` int NOT NULL,
   `PUBLISHER_ID` int NOT NULL,


### PR DESCRIPTION
### Status
deployed

### Description
Based on this error :
DBD::mysql::st execute failed: Out of range value for column 'ID' at row 1 at /usr/local/share/perl/5.30.3/Apache/Ocsinventory/Server/Inventory/Software.pm line 56.

I think this is a better aproach for table software to have bigint ID because of the number of softwares are many at every system.




