### PR TITLE
add missing self in SoftwareSearch.php

### DIFF
--- a/require/search/SoftwareSearch.php
+++ b/require/search/SoftwareSearch.php
@@ -103,7 +103,7 @@
                 return self::NAME_TABLE;
             break;
             default :
-                return SOFTWARE_TABLE;
+                return self::SOFTWARE_TABLE;
             break;
         }
     }


### PR DESCRIPTION
### Status
**READY**

### Description
add missing self in SoftwareSearch.php causing PHP warnings + fails when using multisearch on softwares


