### PR TITLE
add softs removal to cron

### DIFF
--- a/crontab/cron_all_software.php
+++ b/crontab/cron_all_software.php
@@ -13,5 +13,5 @@ $_SESSION['OCS']["readServer"] = dbconnect(SERVER_READ, COMPTE_BASE, PSWD_BASE, 
 $software = new AllSoftware();
 
 error_log(print_r("Please wait, software processing is in progress. It could take a few minutes ...", true));
-$insert = $software->software_link_treatment();
 $cleanup = $software->software_cleanup();
+$insert = $software->software_link_treatment();

--- a/crontab/cron_all_software.php
+++ b/crontab/cron_all_software.php
@@ -14,3 +14,4 @@ $software = new AllSoftware();
 
 error_log(print_r("Please wait, software processing is in progress. It could take a few minutes ...", true));
 $insert = $software->software_link_treatment();
+$cleanup = $software->software_cleanup();

--- a/require/softwares/AllSoftware.php
+++ b/require/softwares/AllSoftware.php
@@ -113,4 +113,27 @@ class AllSoftware
         return $result;
     }
 
+     /**
+      * Search for softwares w/ hardware_ids that are no longer registered
+      * in hardware table and delete them from software table
+      */
+    public function software_cleanup() {
+        $sql = "SELECT software.HARDWARE_ID FROM `software` 
+                LEFT JOIN `hardware` ON software.HARDWARE_ID = hardware.ID
+                WHERE hardware.ID IS NULL GROUP BY software.HARDWARE_ID";
+        $result = mysql2_query_secure($sql, $_SESSION['OCS']['readServer']);
+        $i = 0;
+        while ($hid = mysqli_fetch_array($result)) {
+            $unlinked_hids[$i] = $hid['HARDWARE_ID'];
+            $i++;
+        }
+
+        if ($unlinked_hids >= 1) {
+            $sql_del = "DELETE FROM software WHERE HARDWARE_ID IN (%s)";
+            $arg_del = implode(",", $unlinked_hids);
+            $result = mysql2_query_secure($sql_del, $_SESSION['OCS']["writeServer"], $arg_del);
+        }
+        
+    }
+
 }


### PR DESCRIPTION
### Status
**READY**

### Description
Remove softwares entries with hardware_ids no longer linked to any ID in hardware table (this situation may happen when tables are locked during removal/merge of devices)

