### PR TITLE
decode special chars for ldap passwords

### DIFF
--- a/backend/AUTH/methode/ldap.php
+++ b/backend/AUTH/methode/ldap.php
@@ -126,7 +126,7 @@ function ldap_connection() {
     ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
 
     if (ROOT_DN != '' && defined('ROOT_DN')) {
-        $b = ldap_bind($ds, ROOT_DN, ROOT_PW);
+        $b = ldap_bind($ds, ROOT_DN, htmlspecialchars_decode(ROOT_PW));
     } else { //Anonymous bind
         $b = ldap_bind($ds);
     }


### PR DESCRIPTION
### Status
**READY** 

### Description
Fix #888 , ldap passwords with special characters (such as & and quote symbols) are stored encoded, this will decode them to allow users to connect through ldap.


