### PR TITLE
Send WOL packets to broadcast

### DIFF
--- a/plugins/main_sections/ms_computer/ms_computer.php
+++ b/plugins/main_sections/ms_computer/ms_computer.php
@@ -59,13 +59,14 @@ echo '<div class="col col-md-10">';
 if (isset($protectedPost["WOL"]) && $protectedPost["WOL"] == 'WOL' && $_SESSION['OCS']['profile']->getRestriction('WOL', 'NO') == "NO") {
     require_once('require/wol/WakeOnLan.php');
     $wol = new Wol();
-    $sql = "select MACADDR,IPADDRESS from networks WHERE (hardware_id=%s) and status='Up'";
+    $sql = "select MACADDR,IPADDRESS,IPMASK from networks WHERE (hardware_id=%s) and status='Up'";
     $arg = array($item->ID);
     $resultDetails = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"], $arg);
     $msg = "";
 
     while ($wol_item = mysqli_fetch_object($resultDetails)) {
-        $wol->look_config_wol($wol_item->IPADDRESS, $wol_item->MACADDR);
+        $broadcast = long2ip(ip2long($wol_item->IPADDRESS) | ~ip2long($wol_item->IPMASK));
+        $wol->look_config_wol($broadcast, $wol_item->MACADDR);
 
         if ($wol->wol_send == $l->g(1282)) {
             msg_info($wol->wol_send . "=>" . $wol_item->MACADDR . "/" . $wol_item->IPADDRESS);

--- a/plugins/main_sections/ms_multi_search/ms_custom_tag.php
+++ b/plugins/main_sections/ms_multi_search/ms_custom_tag.php
@@ -84,13 +84,14 @@
      $wol = new Wol();
 
      if (is_defined($protectedPost['WOL'])) {
-         $sql = "select IPADDRESS,MACADDR from networks WHERE status='Up' and hardware_id in ";
+         $sql = "select IPADDRESS,MACADDR,IPMASK from networks WHERE status='Up' and hardware_id in ";
          $arg = array();
          $tab_result = mysql2_prepare($sql, $arg, $list_id);
          $resultDetails = mysql2_query_secure($tab_result['SQL'], $_SESSION['OCS']["readServer"], $tab_result['ARG']);
          $msg = "";
          while ($item = mysqli_fetch_object($resultDetails)) {
-            $wol->look_config_wol($item->IPADDRESS, $item->MACADDR);
+             $broadcast = long2ip(ip2long($item->IPADDRESS) | ~ip2long($item->IPMASK));
+             $wol->look_config_wol($broadcast, $item->MACADDR);
              $msg .= "<br>" . $wol->wol_send . "=>" . $item->MACADDR . "/" . $item->IPADDRESS;
          }
          msg_info($msg);


### PR DESCRIPTION
WOL packets are sent to the destination IP instead of the destination network broadcast.

On WakeOnLan.php function look_config_wol($broadcast, $macaddr) expects broadcast as parameter but receives the host IP.

### Status
**READY**

### Description
Changes tested on my production environment (segmented network).
