### PR TITLE
fix identified devices not showing properly

### DIFF
--- a/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
+++ b/plugins/main_sections/ms_ipdiscover/ms_ipdiscover.php
@@ -131,7 +131,7 @@ if (isset($protectedPost['onglet'])) {
     $arg['SQL'] .= " AND n.status='Up' 
                     GROUP BY $groupby2
                 )
-				inv ON ipdiscover.$on=inv.$on LEFT JOIN
+				inv ON ipdiscover.$on=inv.$on RIGHT JOIN
 				(
                     SELECT 
                     COUNT(DISTINCT mac) AS c,
@@ -173,7 +173,7 @@ if (isset($protectedPost['onglet'])) {
 
     $arg['SQL'] .= " GROUP BY $groupby3
                 )
-				non_ident on non_ident.$on=inv.$on
+				non_ident on non_ident.$on=ident.$on
             ) 
             ipd";
 


### PR DESCRIPTION
### Status
**READY** (remove the irrevelant words)

### Description
on subnets without any inventoried device, identified devices would not display in result table


