### PR TITLE
fix theme not loading on first install of OCS

### DIFF
--- a/require/function_commun.php
+++ b/require/function_commun.php
@@ -342,12 +342,12 @@ function msg_error($txt, $close = false) {
 }
 
 function html_header($noJavascript = false) {
-    if (!$_SESSION['OCS']['readServer']) {
-        $value_theme['tvalue']['CUSTOM_THEME'] = DEFAULT_THEME;
+    if ($_SESSION['OCS']['readServer']) {
+        $value_theme = look_config_default_values('CUSTOM_THEME');
         
     }
-    if(is_null($value_theme)) {
-        $value_theme = look_config_default_values('CUSTOM_THEME');
+    if (is_null($value_theme)) {
+        $value_theme['tvalue']['CUSTOM_THEME'] = DEFAULT_THEME;
     }
 
     header("Pragma: no-cache");


### PR DESCRIPTION
### Status
**READY** 

### Description
When installing OCS for the first time and accessing ocsreports, the ocs theme would not load


