### PR TITLE
Update 7044.sql

### DIFF
--- a/files/update/7044.sql
+++ b/files/update/7044.sql
@@ -1,2 +1,2 @@
-ALTER TABLE ̀`registry_regvalue_cache` DROP INDEX `REGVALUE`; 
+ALTER TABLE `registry_regvalue_cache` DROP INDEX `REGVALUE`; 
 ALTER TABLE `registry_regvalue_cache` MODIFY `REGVALUE` TEXT;


### PR DESCRIPTION
### Status
**READY

### Description
deleted extra character and fix "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'DROP INDEX `REGVALUE`' at line 1"

### Documentation

