### PR TITLE
Fix ROOT_DN Constant warning when not defined

### DIFF
--- a/backend/AUTH/methode/ldap.php
+++ b/backend/AUTH/methode/ldap.php
@@ -139,7 +139,7 @@ function ldap_connection() {
     ldap_set_option($ds, LDAP_OPT_PROTOCOL_VERSION, LDAP_PROTOCOL_VERSION);
     ldap_set_option($ds, LDAP_OPT_REFERRALS, 0);
 
-    if (ROOT_DN != '' && defined('ROOT_DN')) {
+    if (defined('ROOT_DN') && ROOT_DN != '') {
         $b = ldap_bind($ds, ROOT_DN, htmlspecialchars_decode(ROOT_PW));
     } else { //Anonymous bind
         $b = ldap_bind($ds);


### PR DESCRIPTION
### Status
**READY**

### Description
The following warning occurs when login using ldap:
```
PHP Warning:  Use of undefined constant ROOT_DN - assumed 'ROOT_DN' (this will throw an Error in a future version of PHP) in /usr/share/ocsinventory-reports/ocsreports/backend/AUTH/methode/ldap.php on line 158
```

The warning is thrown because the content of `ROOT_DN` is checked before the `defined(ROOT_DN)` is issued.