### PR TITLE
display correct error msg when user with no rights

### DIFF
--- a/backend/identity/methode/cas.php
+++ b/backend/identity/methode/cas.php
@@ -108,7 +108,7 @@ if (isset($defaultRole) && trim($defaultRole) != '') {
         $profile = $profile_serializer->unserialize($lvluser, file_get_contents($profile_config));
 
         $restriction = $profile->getRestriction('GUI');
-
+        $restrictions = $profile->getRestrictions();
         //if this user has RESTRICTION
         //search all tag for this user
         if ($restriction == 'YES') {
@@ -136,6 +136,12 @@ if (isset($defaultRole) && trim($defaultRole) != '') {
             if (!isset($list_tag)) {
                 $ERROR = $l->g(893);
             }
+    
+            // if user is restricted on all pages and has no tag assigned, he has the right to connect but no access
+            if (!isset($list_tag) && !in_array('NO', $restrictions)) {
+                $ERROR = $l->g(896);
+            }
+    
         } elseif (($restriction != 'NO')) {
             $ERROR = $restriction;
         }

--- a/backend/identity/methode/ldap.php
+++ b/backend/identity/methode/ldap.php
@@ -154,7 +154,7 @@ if (isset($defaultRole) && trim($defaultRole) != '') {
         $profile = $profile_serializer->unserialize($lvluser, file_get_contents($profile_config));
 
         $restriction = $profile->getRestriction('GUI');
-
+        $restrictions = $profile->getRestrictions();
         //if this user has RESTRICTION
         //search all tag for this user
         if ($restriction == 'YES') {
@@ -182,6 +182,12 @@ if (isset($defaultRole) && trim($defaultRole) != '') {
             if (!isset($list_tag)) {
                 $ERROR = $l->g(893);
             }
+    
+            // if user is restricted on all pages and has no tag assigned, he has the right to connect but no access
+            if (!isset($list_tag) && !in_array('NO', $restrictions)) {
+                $ERROR = $l->g(896);
+            }
+    
         } elseif (($restriction != 'NO')) {
             $ERROR = $restriction;
         }

--- a/backend/identity/methode/local.php
+++ b/backend/identity/methode/local.php
@@ -54,7 +54,7 @@ if (isset($rowOp->accesslvl)) {
     $profile = $profile_serializer->unserialize($lvluser, file_get_contents($profile_config));
 
     $restriction = $profile->getRestriction('GUI');
-
+    $restrictions = $profile->getRestrictions();
     //Si l'utilisateur a des droits limités
     //on va rechercher les tags sur lesquels il a des droits
     if ($restriction == 'YES') {
@@ -79,9 +79,16 @@ if (isset($rowOp->accesslvl)) {
                 $list_tag[$row->tag] = $row->tag;
             }
         }
+
         if (!isset($list_tag)) {
             $ERROR = $l->g(893);
         }
+
+        // if user is restricted on all pages and has no tag assigned, he has the right to connect but no access
+        if (!isset($list_tag) && !in_array('NO', $restrictions)) {
+            $ERROR = $l->g(896);
+        }
+
     } elseif ($restriction != 'NO') {
         $ERROR = $restriction;
     }

--- a/plugins/language/en_GB/en_GB.txt
+++ b/plugins/language/en_GB/en_GB.txt
@@ -781,6 +781,7 @@
 893 NO TAG ASSIGNED TO YOUR PROFILE
 894 No rights level defined to your profile, please contact your administrator
 895 TAG Modification
+896 You do not have rights to access this page, please contact your administrator
 898 Add an annotation
 899 Writer
 900 Do you really want to delete selection?

--- a/plugins/language/fr_FR/fr_FR.txt
+++ b/plugins/language/fr_FR/fr_FR.txt
@@ -782,6 +782,7 @@
 893 PAS DE TAG AFFECTE A VOTRE PROFIL
 894 Aucun niveau de droits n'a été défini pour votre profil, merci de contacter votre administrateur
 895 Modification d'un TAG
+896 Vous n'avez pas accès à cette page, veuillez contacter votre administrateur
 898 Ajouter une annotation
 899 Rédacteur
 900 Etes-vous sûr de vouloir supprimer la sélection?


### PR DESCRIPTION
### Status
**READY** 

### Description
If user has a profile with all restrictions set to yes,  no rights to consults any pages and not tag assigned, display the error msg accordingly when connecting to the GUI


