### PR TITLE
fix grp select in cd_configuration

### DIFF
--- a/plugins/computer_detail/cd_configuration/cd_configuration.php
+++ b/plugins/computer_detail/cd_configuration/cd_configuration.php
@@ -75,7 +75,7 @@ echo open_form($form_name, '', '', 'form-horizontal');
         $hrefBase = "index.php?" . PAG_INDEX . "=" . $pages_refs['ms_computer'] . "&head=1&systemid=" . urlencode($systemid) . "&option=cd_configuration";
 
         $reqGroups = "SELECT h.name,h.id,h.workgroup
-					  FROM hardware h,groups g
+					  FROM hardware h,`groups` g
 					  WHERE  g.hardware_id=h.id  and h.deviceid='_SYSTEMGROUP_'";
         if (!($_SESSION['OCS']['profile']->getConfigValue('GROUPS') == "YES")) {
             $reqGroups .= " and workgroup = 'GROUP_4_ALL'";


### PR DESCRIPTION
### Status
**READY** (remove the irrevelant words)

### Description
Select of group in cd_configuration could not be used due to mysql reserved keyword 'groups'



