### PR TITLE
Fix CVE Vendor normalize removes dash

### DIFF
--- a/require/cve/Cve.php
+++ b/require/cve/Cve.php
@@ -225,7 +225,7 @@ class Cve
     $vendor = preg_replace("/,?\s*(corporation|gmbh|inc\.|incorporated|LLC|spol\.\ss\sr\.o\.|systems\sinc\.|systems\sincorporated|copyright)$/", "", $vendor);
     $vendor = preg_replace("/\s*\(r\)/", "", $vendor);
     $vendor = preg_replace('/[^\x00-\x7F]/', "", $vendor);
-    $vendor = preg_replace("/[^A-Za-z0-9\._]/", "", $vendor);
+    $vendor = preg_replace("/[^A-Za-z0-9\._-]/", "", $vendor);
     $vendor = trim($vendor);
     
     return preg_replace("/\s/", "_", $vendor);


### PR DESCRIPTION
### Status
**READY**

### Description
The function cpeNormalizeVendor in the Cve class removed the dash
('-') character which is an allowed vendor name part. This is fixed
by updating the related replacement regex.

