### PR TITLE
Fix actions on groups and visibility

### DIFF
--- a/plugins/computer_detail/cd_configuration/cd_configuration.php
+++ b/plugins/computer_detail/cd_configuration/cd_configuration.php
@@ -216,7 +216,7 @@ if (mysqli_num_rows($resGroups) > 0) {
         echo ")";
         echo "<br />";
 
-        if ($_SESSION['OCS']['profile']->getConfigValue('GROUPS') == "YES" || $valGroups["workgroup"] == "GROUP_4_ALL") {
+        if ($_SESSION['OCS']['profile']->getConfigValue('GROUPS') == "YES" && $valGroups["workgroup"] == "GROUP_4_ALL") {
             $hrefBase = "index.php?" . PAG_INDEX . "=" . $pages_refs['ms_computer'] . "&head=1&systemid=" . urlencode($systemid) . "&option=cd_configuration&grp=" . $valGroups["group_id"];
             switch ($valGroups["static"]) {
                 case 0: echo "<a href='$hrefBase&actgrp=1'>" . $l->g(598) . "</a> / <a href='$hrefBase&actgrp=2'>" . $l->g(600) . "</a>";

--- a/plugins/computer_detail/cd_configuration/cd_configuration.php
+++ b/plugins/computer_detail/cd_configuration/cd_configuration.php
@@ -64,6 +64,9 @@ echo open_form($form_name, '', '', 'form-horizontal');
         if ($_SESSION['OCS']['profile']->getConfigValue('CONFIG') == "YES") {
             echo "<a href=\"index.php?" . PAG_INDEX . "=" . $pages_refs['ms_custom_param'] . "&head=1&idchecked=" . $systemid . "&origine=machine\" alt=". $l->g(2122) ." class='btn btn-success'>". $l->g(2122) ."</a>";
         }
+
+        // if user has permission to add devices to groups (Manage groups perm), show the group selector
+        if ($_SESSION['OCS']['profile']->getConfigValue('GROUPS') == "YES") {
         ?>
     </div>
 </div></br></br>
@@ -101,6 +104,7 @@ echo open_form($form_name, '', '', 'form-horizontal');
 </div></br></br>
 
 <?php
+}
 while ($item = mysqli_fetch_array($resultDetails, MYSQLI_ASSOC)) {
     $optPerso[$item["NAME"]]["IVALUE"] = $item["IVALUE"];
     $optPerso[$item["NAME"]]["TVALUE"] = $item["TVALUE"];

--- a/plugins/main_sections/ms_groups/ms_groups.php
+++ b/plugins/main_sections/ms_groups/ms_groups.php
@@ -76,19 +76,14 @@ $tab_options['form_name'] = $form_name;
 
 echo open_form($form_name, '', '', 'form-horizontal');
 //view all groups
-if ($_SESSION['OCS']['profile']->getConfigValue('GROUPS')=="YES"){
-	$def_onglets['DYNA']=$l->g(810); //Dynamic group
-	$def_onglets['STAT']=$l->g(809); //Static group centraux
-	if (empty($protectedPost['onglet']))
-	$protectedPost['onglet']="STAT";	
-	//show onglet
-	show_tabs($def_onglets,$form_name,"onglet",true);
-	echo '<div class="col col-md-10">';
+$def_onglets['DYNA']=$l->g(810); //Dynamic group
+$def_onglets['STAT']=$l->g(809); //Static group centraux
+if (empty($protectedPost['onglet']))
+$protectedPost['onglet']="STAT";	
+//show onglet
+show_tabs($def_onglets,$form_name,"onglet",true);
+echo '<div class="col col-md-10">';
 
-
-}else{	
-	$protectedPost['onglet']="STAT";
-}
 
 $list_fields = array('GROUP_NAME' => 'h.NAME',
     'GROUP_ID' => 'h.ID',
@@ -97,7 +92,7 @@ $list_fields = array('GROUP_NAME' => 'h.NAME',
     'NBRE' => 'NBRE');
 //only for admins
 if ($_SESSION['OCS']['profile']->getConfigValue('GROUPS') == "YES") {
-    if ($protectedPost['onglet'] == "STAT") {
+    if ($protectedPost['onglet'] == "STAT" || $protectedPost['onglet'] == "DYNA") {
         $list_fields['CHECK'] = 'ID';
     }
     $list_fields['SUP'] = 'ID';
@@ -160,7 +155,7 @@ if (!isset($tab_options['VALUE']['NBRE'])) {
     $tab_options['VALUE']['NBRE'][] = 0;
 }
 //on recherche les groupes visible pour cocher la checkbox à l'affichage
-if ($protectedPost['onglet'] == "STAT") {
+if ($protectedPost['onglet'] == "STAT" || $protectedPost['onglet'] == "DYNA") {
     $sql = "select id from hardware where workgroup='GROUP_4_ALL'";
     $result = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"]);
     while ($item = mysqli_fetch_object($result)) {


### PR DESCRIPTION
### Status
**READY**

### Description
* Fix visibility checkboxes not displaying for dynamic groups and dynamic groups not being displayed coherently
* Hide the group selector in a computer configuration if user does not have the 'manage groups' permission (also makes the option to remove computer from the group unavailable)



