### PR TITLE
Fix doesntcontain in multisearch

### DIFF
--- a/require/search/SQLCache.php
+++ b/require/search/SQLCache.php
@@ -126,39 +126,15 @@
 
                 unset($value['ignore']);
 
-                if($value[Search::SESS_OPERATOR] == "DOESNTCONTAIN" && empty($doesntcontainmulti)){
-                    $excluID = $this->search->contain($value, $nameTable);
-                    if($nameTable != DatabaseSearch::COMPUTER_DEF_TABLE){
-                        $value[Search::SESS_FIELDS] = "HARDWARE_ID";
-                    }else{
-                        $value[Search::SESS_FIELDS] = "ID";
-                    }
-                    
-                    $value[Search::SESS_VALUES] = implode(',', $excluID);
-                    $value[Search::SESS_OPERATOR] = "NOT IN";
-
-                }elseif($value[Search::SESS_OPERATOR] == "DOESNTCONTAIN" && !empty($isSameColumn) && !empty($doesntcontainmulti)){
-                    $excluID = $this->search->containmulti($isSameColumn, $searchInfos);
-                    if($nameTable != DatabaseSearch::COMPUTER_DEF_TABLE){
-                        $value[Search::SESS_FIELDS] = "HARDWARE_ID";
-                    }else{
-                        $value[Search::SESS_FIELDS] = "ID";
-                    }
-                    
-                    $value[Search::SESS_VALUES] = implode(',', $excluID);
-                    $value[Search::SESS_OPERATOR] = "NOT IN";
-                    $value['ignore'] = "";
-                }
-
                 $argFields = $value[Search::SESS_FIELDS];
                 $argOperators = $value[Search::SESS_OPERATOR];
                 $argValues = $value[Search::SESS_VALUES] ?? '';
 
                 if(!empty($isSameColumn) && $isSameColumn[$nameTable] == $value[Search::SESS_FIELDS] 
-                            && !array_key_exists("ignore", $value) && !array_key_exists('devices', $isSameColumn)){
+                            && !array_key_exists("ignore", $value) && !array_key_exists('devices', $isSameColumn) && $value[Search::SESS_OPERATOR] != "DOESNTCONTAIN"){
                     if($value[Search::SESS_OPERATOR] != "IS NULL"){
                         if ($nameTable != DatabaseSearch::COMPUTER_DEF_TABLE&& $nameTable != self::GROUP_TABLE && $value[Search::SESS_FIELDS] != 'CATEGORY_ID' && $value[Search::SESS_FIELDS] != 'CATEGORY' 
-                        && $value[Search::SESS_OPERATOR] != "NOT IN") {
+                        && $value[Search::SESS_OPERATOR] != "NOT IN" && $value[Search::SESS_OPERATOR] != "ISNOTEMPTY") {
                             $this->columnsQueryConditions .= "$operator[$p] $open EXISTS (
                                     SELECT 1 FROM $nameTable 
                                     WHERE hardware.ID = $nameTable.HARDWARE_ID 
@@ -227,6 +203,16 @@
                 }elseif($value[Search::SESS_OPERATOR] == "MORETHANXDAY" || $value[Search::SESS_OPERATOR] == "LESSTHANXDAY") {
                     if($value[Search::SESS_OPERATOR] == "MORETHANXDAY") { $op = "<"; } else { $op = ">"; }
                     $this->columnsQueryConditions .= "$operator[$p] $open $nameTable.$argFields $op NOW() - INTERVAL $argValues DAY $close ";
+                }elseif ($value[Search::SESS_OPERATOR] == "DOESNTCONTAIN"){
+                    $result = $this->search->contain_subquery($nameTable, $value);
+                    if($tableName == DatabaseSearch::COMPUTER_DEF_TABLE || substr($nameTable, 0, 9) == 'software_'){
+                        
+                        $value[Search::SESS_FIELDS] = "ID";
+                        }else{
+                        $value[Search::SESS_FIELDS] = "HARDWARE_ID";
+                        }
+                    $this->columnsQueryConditions .= " $operator[$p] $open hardware.ID NOT IN ($result) $close ";
+
                 }else{
                     if($nameTable == "download_history" && $value[Search::SESS_FIELDS] == "PKG_NAME"){
                         $this->columnsQueryConditions .= "$operator[$p] $open download_available.NAME $argOperators '$argValues' $close ";

--- a/require/search/Search.php
+++ b/require/search/Search.php
@@ -395,26 +395,35 @@
 
               if($value[self::SESS_OPERATOR] == "DOESNTCONTAIN" && empty($doesntcontainmulti)){
                 $excluID = $this->contain($value, $nameTable);
-                if($nameTable != DatabaseSearch::COMPUTER_DEF_TABLE){
-                $value[self::SESS_FIELDS] = "HARDWARE_ID";
-                }else{
-                $value[self::SESS_FIELDS] = "ID";
-                }
-                
-                $value[self::SESS_VALUES] = implode(',', $excluID);
+                if($tableName == DatabaseSearch::COMPUTER_DEF_TABLE || substr($nameTable, 0, 8) == 'software') {
+                  $value[self::SESS_FIELDS] = "ID";
+                  }else{
+                  $value[self::SESS_FIELDS] = "HARDWARE_ID";
+                  }
+                $value[self::SESS_VALUES] = is_array($excluID) ? implode(',', $excluID) : $excluID;
                 $value[self::SESS_OPERATOR] = "NOT IN";
 
               }elseif($value[self::SESS_OPERATOR] == "DOESNTCONTAIN" && !empty($isSameColumn) && !empty($doesntcontainmulti)){
                 $excluID = $this->containmulti($isSameColumn, $searchInfos);
-                if($nameTable != DatabaseSearch::COMPUTER_DEF_TABLE){
-                $value[self::SESS_FIELDS] = "HARDWARE_ID";
-                }else{
+                if($tableName == DatabaseSearch::COMPUTER_DEF_TABLE || substr($nameTable, 0, 8) == 'software') {
+                  $value[self::SESS_FIELDS] = "ID";
+                  }else{
+                  $value[self::SESS_FIELDS] = "HARDWARE_ID";
+                  }
+
+                $value[self::SESS_VALUES] = implode(',', $excluID);
+                $value[self::SESS_OPERATOR] = "NOT IN";
+                $value['ignore'] = "";
+              }elseif($value[self::SESS_OPERATOR] == "DOESNTCONTAIN") {
+                $excluID = $this->contain($value, $nameTable);
+                if($tableName == DatabaseSearch::COMPUTER_DEF_TABLE || substr($nameTable, 0, 9) == 'software_'){
                 $value[self::SESS_FIELDS] = "ID";
+                }else{
+                $value[self::SESS_FIELDS] = "HARDWARE_ID";
                 }
                 
                 $value[self::SESS_VALUES] = implode(',', $excluID);
                 $value[self::SESS_OPERATOR] = "NOT IN";
-                $value['ignore'] = "";
               }
 
               if(!empty($isSameColumn) && $isSameColumn[$nameTable] == $value[self::SESS_FIELDS] 
@@ -513,15 +522,18 @@
                     || $value[self::SESS_OPERATOR] == "NOT IN"){
                 $this->columnsQueryConditions .= "$operator[$p] $open%s.%s %s (%s)$close ";
                 if($nameTable == self::GROUP_TABLE){
-                $this->queryArgs[] = 'hardware';
-                $this->queryArgs[] = 'ID';
-                $this->queryArgs[] = $value[self::SESS_OPERATOR];
-                $this->queryArgs[] = $this->groupSearch->get_all_id($value[self::SESS_VALUES]);
+                  $this->queryArgs[] = 'hardware';
+                  $this->queryArgs[] = 'ID';
+                  $this->queryArgs[] = $value[self::SESS_OPERATOR];
+                  $this->queryArgs[] = $this->groupSearch->get_all_id($value[self::SESS_VALUES]);
                 }else{
-                $this->queryArgs[] = $nameTable;
-                $this->queryArgs[] = $value[self::SESS_FIELDS];
-                $this->queryArgs[] = $value[self::SESS_OPERATOR];
-                $this->queryArgs[] = $value[self::SESS_VALUES];
+                  if(substr($nameTable, 0, 8) == 'software') {
+                    $nameTable = 'hardware';
+                  }
+                  $this->queryArgs[] = $nameTable;
+                  $this->queryArgs[] = $value[self::SESS_FIELDS];
+                  $this->queryArgs[] = 'NOT IN';
+                  $this->queryArgs[] = $value[self::SESS_VALUES];
                 }
               // test fix datetime in multisearch
               }else if($this->getSearchedFieldType($nameTable, $value[self::SESS_FIELDS]) == 'datetime' && $value[self::SESS_OPERATOR] != "MORETHANXDAY" && $value[self::SESS_OPERATOR] != "LESSTHANXDAY" ){
@@ -1244,22 +1256,31 @@
      * Doesn't contain traitment
      */
     public function contain($value, $tableName){
-      if($tableName != DatabaseSearch::COMPUTER_DEF_TABLE){
-        $field = "HARDWARE_ID";
-      }else{
+       // if table is hardware or table name begins with 'software_' : field name is ID
+      if($tableName == DatabaseSearch::COMPUTER_DEF_TABLE || substr($tableName, 0, 9) == 'software_') {
         $field = "ID";
-      }
-      $sql_search = "SELECT DISTINCT %s FROM %s WHERE %s LIKE '%s'";
-      $sql_search_arg = array($field, $tableName, $value['fields'], "%".$value['value']."%");
-      $result = mysql2_query_secure($sql_search, $_SESSION['OCS']["readServer"], $sql_search_arg);
-
-      while($notcontain = mysqli_fetch_array($result)){
-        $excluID[] = $notcontain[$field];
+      } elseif ($tableName != DatabaseSearch::COMPUTER_DEF_TABLE) {
+        $field = "HARDWARE_ID";
       }
 
-      if($excluID[0] == null){
-        $excluID[0] = 0;
+      // if search is software related, process is slighty different
+      if (substr($tableName, 0, 9) == 'software_') {
+        $crit = $value['value'];
+        $result = $this->contain_search($tableName, $crit);
+      } else {
+        // classic way for other tables
+        $sql_search = "SELECT DISTINCT %s FROM %s WHERE %s LIKE '%s'";
+        $sql_search_arg = array($field, $tableName, $value['fields'], "%".$value['value']."%");
+        $result = mysql2_query_secure($sql_search, $_SESSION['OCS']["readServer"], $sql_search_arg);
       }
+
+          while($notcontain = mysqli_fetch_array($result)) {
+            $excluID[] = $notcontain[$field];
+          }
+    
+          if(!isset($excluID) || $excluID[0] == null){
+            $excluID[0] = 0;
+          }
 
       return $excluID;
     }
@@ -1275,10 +1296,11 @@
         $column = $field;
       }
 
-      if($tablename != DatabaseSearch::COMPUTER_DEF_TABLE){
-        $fieldname = "HARDWARE_ID";
-      }else{
+      // if table is hardware or table name begins with 'software_' : field name is ID
+      if($tablename == DatabaseSearch::COMPUTER_DEF_TABLE || substr($tablename, 0, 9) == 'software_') {
         $fieldname = "ID";
+      } elseif ($tablename != DatabaseSearch::COMPUTER_DEF_TABLE) {
+        $fieldname = "HARDWARE_ID";
       }
 
       foreach ($value as $values){
@@ -1291,11 +1313,16 @@
       }
 
       for($i = 0; $i != count($comparator)+1; $i++){
-
-        $sql = "SELECT DISTINCT %s FROM %s WHERE %s LIKE '%s'";
-        $sql_arg = array($fieldname, $tablename, $column, "%".$search[$i]."%");
-
-        $result = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"], $sql_arg);
+        // if search is software related, process is slighty different
+        if (substr($tablename, 0, 9) == 'software_') {
+          $crit = $search[$i];
+          $result = $this->contain_search($tablename, $crit);
+        } else {
+          // classic way for other tables
+          $sql = "SELECT DISTINCT %s FROM %s WHERE %s LIKE '%s'";
+          $sql_arg = array($fieldname, $tablename, $column, "%".$search[$i]."%");
+          $result = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"], $sql_arg);
+        }
 
         while($notcontain = mysqli_fetch_array($result)){
           $excluID[$notcontain[$fieldname]] = $notcontain[$fieldname];
@@ -1313,10 +1340,25 @@
         }
       }
 
-      if($excluID == null){
+      if(!isset($excluID) || array_key_first($excluID) == null){
         $excluID[0] = 0;
       }
 
       return $excluID;
     }
- }
+
+    /**
+     * Handling of doesntcontain operator if search is made on software tables
+     * Returns : mysqli_result containing hardware_ids to exclude
+     */
+    protected function contain_search($tableName, $value) {
+      $main_col = substr($tableName, strpos($tableName, "_") + 1);
+      $id_col = $main_col.'_id';
+      
+      $sql_search = "SELECT DISTINCT hardware.ID FROM hardware INNER JOIN software on hardware.id = software.hardware_id LEFT JOIN $tableName on $tableName.id = software.$id_col WHERE $tableName.$main_col LIKE '%s' GROUP BY hardware.id";
+      $sql_search_arg = array("%".$value."%");
+      $result = mysql2_query_secure($sql_search, $_SESSION['OCS']["readServer"], $sql_search_arg);
+
+      return $result; 
+    }
+  }


### PR DESCRIPTION
### Status
**READY** 

### Description
Fix doesntcontain operator not working with software tables + uses a subquery instead of list of IDs to keep dynamic groups dynamic 


