### PR TITLE
Remove utf-8 encode on software select in software categories

### DIFF
--- a/plugins/main_sections/ms_soft_cat/ms_options_soft_cat.php
+++ b/plugins/main_sections/ms_soft_cat/ms_options_soft_cat.php
@@ -43,7 +43,7 @@ $i = 0;
 if (!empty($liste)) {
     foreach ($liste as $element) {
         if ($i < $MAX_RETURN && strtolower(substr($element['NAME'], 0, strlen($debut))) == $debut) {
-            echo(utf8_encode("<option>" . $element['NAME'] . "</option>"));
+            echo "<option>" . $element['NAME'] . "</option>";
             $i++;
         }
     }


### PR DESCRIPTION
### Status
**READY** (remove the irrevelant words)

### Description
Remove utf-8 encode on software select in software categories to fix utf-8 wrong display

### Documentation
In the case, your pull request need the documentation to be modified, please say it here.
You can also directly create a pull request for the documentation here : https://github.com/OCSInventory-NG/Wiki

Note : Merge process will be faster if the documentation is already written


