### PR TITLE
fix(deployment): fix end of line encoding for linux/macos 

### DIFF
--- a/require/teledeploy/PackageBuilder.php
+++ b/require/teledeploy/PackageBuilder.php
@@ -97,6 +97,11 @@ class PackageBuilder
 
 		if((isset($post['getcode']) && trim($post['getcode']) != "")) {
 			$script = $downloadPath.'/'.$xmlDetails->packagebuilder->codeasfile->filename;
+			
+			// if os is linux or macos, CRLF needs to be replaced by LF
+			if ($post['os_selected'] == 'linux' || $post['os_selected'] == 'macos') {
+				$post['getcode'] = str_replace("\r\n", "\n", $post['getcode']);
+			}
 			// Create script file
 			$handscript = fopen($script, "w+");
 			fwrite($handscript, $post['getcode']);


### PR DESCRIPTION

### Status
**READY**

### Description
When building a package, if the code input section was used to create a script, the encoding for end of lines would be CRLF and script would fail when deployed on linux or macos devices


