### PR TITLE
CVE Inventory page - remove unnsecesary dir part from URL

### DIFF
--- a/plugins/main_sections/ms_cve_correspondance/ms_cve_correspondance.php
+++ b/plugins/main_sections/ms_cve_correspondance/ms_cve_correspondance.php
@@ -87,6 +87,8 @@ if($protectedPost['onglet'] == "NEW_CORR") {
     echo "<div class='row margin-top30'>
             <div class='col-sm-10'>";
 
+    $dir = dirname($_SERVER['REQUEST_URI']);
+    $url = $url.$dir;
     echo "<a href='".$url."/files/cve/cve_matching_mostknown.csv' download>".$l->g(1480)."</a>";
     echo "<br><br>";
     formGroup('file', 'csv_file', $l->g(1478).' :', '', '', $protectedPost['csv_file'] ?? '', '', '', '', "accept='.csv'");

--- a/plugins/main_sections/ms_cve_correspondance/ms_cve_correspondance.php
+++ b/plugins/main_sections/ms_cve_correspondance/ms_cve_correspondance.php
@@ -87,7 +87,7 @@ if($protectedPost['onglet'] == "NEW_CORR") {
     echo "<div class='row margin-top30'>
             <div class='col-sm-10'>";
 
-    echo "<a href='".$url."/ocsreports/files/cve/cve_matching_mostknown.csv' download>".$l->g(1480)."</a>";
+    echo "<a href='".$url."/files/cve/cve_matching_mostknown.csv' download>".$l->g(1480)."</a>";
     echo "<br><br>";
     formGroup('file', 'csv_file', $l->g(1478).' :', '', '', $protectedPost['csv_file'] ?? '', '', '', '', "accept='.csv'");
     echo "<input type='submit' name='valid_csv' id='valid_csv' class='btn btn-success' value='".$l->g(1479)."'>";


### PR DESCRIPTION
### Status

READY/

### Description

Removed unnecessary /ocsreports/ part from URL. When accessing OCSReports by URL without /ocsreports/ part in its URL, link to an example file is incorrect, i.e.:
CVE Inventory -> New matching regex:
https://ocs.mydomain.com/index.php?function=cve_correspondance

"Download CSV file example" was created like this: https://ocs.mydomain.com/ocsreports/files/cve/csv_example.csv

### Documentation

No need to change documentation.
