### PR TITLE
Destroy Sessions for cronjobs

### DIFF
--- a/crontab/cron_all_software.php
+++ b/crontab/cron_all_software.php
@@ -36,3 +36,5 @@ print("[".date("Y-m-d H:i:s"). "] End of clean\n");
 print("[".date("Y-m-d H:i:s"). "] Start to process software by pool of ".$chunk."\n");
 $insert = $software->software_link_treatment($chunk);
 print("[".date("Y-m-d H:i:s"). "] End of process\n");
+
+session_destroy();

--- a/crontab/cron_clean_orphan.php
+++ b/crontab/cron_clean_orphan.php
@@ -31,3 +31,5 @@ if($queryList) {
 }
 
 print("[".date("Y-m-d H:i:s"). "] End of process\n");
+
+session_destroy();

--- a/crontab/cron_cve.php
+++ b/crontab/cron_cve.php
@@ -46,3 +46,5 @@ if($cve->CVE_ACTIVE == 1) {
     $cve->verbose($cve->CVE_VERBOSE, 3);
     exit();
 }?>
+
+session_destroy();

--- a/crontab/cron_cve.php
+++ b/crontab/cron_cve.php
@@ -45,6 +45,7 @@ if($cve->CVE_ACTIVE == 1) {
 } else {
     $cve->verbose($cve->CVE_VERBOSE, 3);
     exit();
-}?>
+}
 
 session_destroy();
+?>

--- a/crontab/cron_cve_computer.php
+++ b/crontab/cron_cve_computer.php
@@ -60,4 +60,6 @@ if($cve->CVE_ACTIVE == 1) {
     $cve->verbose($cve->CVE_VERBOSE, 3);
     exit();
 }
+
+session_destroy();
 ?>

--- a/crontab/cron_ipdiscover.php
+++ b/crontab/cron_ipdiscover.php
@@ -36,3 +36,5 @@ if($ipdiscoverPurgeConfig["ivalue"]["IPDISCOVER_PURGE_OLD"] == "1"){
 
     print("[".date("Y-m-d H:i:s"). "] ".$resultCount->num_rows." devices have been removed\n");
 }
+
+session_destroy();

--- a/crontab/cron_purge_history.php
+++ b/crontab/cron_purge_history.php
@@ -15,4 +15,6 @@ $reqDelHistory = "DELETE FROM `download_history` WHERE PKG_ID NOT IN (SELECT FIL
 mysql2_query_secure($reqDelHistory, $_SESSION['OCS']["writeServer"]);
 
 print("[".date("Y-m-d H:i:s"). "] Download history has been purged of removed packages\n");
+
+session_destroy();
 ?>

--- a/crontab/cron_report_notification.php
+++ b/crontab/cron_report_notification.php
@@ -25,7 +25,4 @@ if ($scheduled != '') {
     $sendNotifs = $groupReport->sendReportNotification($scheduled, $values, $groupReport);
 }
 
-
-
-
-
+session_destroy();

--- a/crontab/cron_wol.php
+++ b/crontab/cron_wol.php
@@ -43,3 +43,4 @@ if (!empty($wol)) {
   }
 }
 
+session_destroy();


### PR DESCRIPTION
### Status
**READY**

### Description
All cronjobs create a session that leaves a session file after the script run which is not needed in the future. Add a session_destroy at the end of every cron script to avoid deleting unnessessary session files on disk.

### Documentation
No Update needed

Note : Merge process will be faster if the documentation is already written


