### PR TITLE
fix(accountinfo): prevent use of quotes in admin data

### DIFF
--- a/plugins/computer_detail/cd_admininfo/cd_admininfo.php
+++ b/plugins/computer_detail/cd_admininfo/cd_admininfo.php
@@ -78,7 +78,8 @@ if (!is_array($info_account_id)) {
                 }
 
             }
-            $Admininfo->updateinfo_computer($systemid, $data_fields_account);
+            $result = $Admininfo->updateinfo_computer($systemid, $data_fields_account);
+            msg_info($result);
             //search all admininfo for this computer
             $info_account_id = $Admininfo->admininfo_computer($systemid);
         }

--- a/plugins/language/en_GB/en_GB.txt
+++ b/plugins/language/en_GB/en_GB.txt
@@ -1913,3 +1913,5 @@
 9989 Download SNMP Scan Configuration
 9990 Download SNMP Subnets List
 9991 Generate SNMP files
+
+10000 Failed to update account info fields: quotes are not allowed in administrative values

--- a/plugins/language/fr_FR/fr_FR.txt
+++ b/plugins/language/fr_FR/fr_FR.txt
@@ -1908,3 +1908,5 @@
 9989 Télécharger la configuration du scan SNMP
 9990 Télécharger la liste des réseaux SNMP
 9991 Génère les fichiers SNMP
+
+10000 Échec de la mise à jour des données administratives : les simples et doubles guillements ne sont pas autorisés dans la valeur

--- a/plugins/main_sections/ms_multi_search/ms_custom_tag.php
+++ b/plugins/main_sections/ms_multi_search/ms_custom_tag.php
@@ -67,7 +67,8 @@
          }
 
          if (!empty($data_fields_account)) {
-             $Admininfo->updateinfo_computer($list_id, $data_fields_account, 'LIST');
+             $res = $Admininfo->updateinfo_computer($list_id, $data_fields_account, 'LIST');
+             msg_info($res);
              unset($_SESSION['OCS']['DATA_CACHE']['TAB_MULTICRITERE']);
              echo "<script language='javascript'> window.opener.document.multisearch.submit();</script>";
              echo "<script language='javascript'> window.opener.document.show_all.submit();</script>";

--- a/require/admininfo/Admininfo.php
+++ b/require/admininfo/Admininfo.php
@@ -472,6 +472,11 @@ class Admininfo
 		$sql_account_data = "UPDATE ".self::ACCOUNTINFO_COMPUTERS." SET ";
 
 		foreach ($values as $field => $val) {
+			# quotes are not allowed in administrative value
+			if (preg_match('/(&quot;|&#039;|&apos;)/', $val)) {
+				return $l->g(10000);
+			}
+		
 			// Check account info
 			$accountinfo_id = explode("_", $field);
 			$date_accountinfo = false;


### PR DESCRIPTION
### Status
**READY**

### Description
Prevent user from entering quote symbols (simple and double) in administrative values


