### PR TITLE
Fix header.php Error 500 on logout

### DIFF
--- a/require/header.php
+++ b/require/header.php
@@ -202,13 +202,15 @@ if (!isset($_SESSION['OCS']['SQL_TABLE'])) {
         $sql = "SHOW COLUMNS FROM `%s`";
         $arg = $item[0];
         $res_column = mysql2_query_secure($sql, $_SESSION['OCS']["readServer"], $arg);
-        while ($item_column = mysqli_fetch_row($res_column)) {
-
-            if ($item_column[0] == "HARDWARE_ID" && !isset($_SESSION['OCS']['SQL_TABLE_HARDWARE_ID'][$item[0]])) {
-                $_SESSION['OCS']['SQL_TABLE_HARDWARE_ID'][$item[0]] = $item[0];
+        if ($res_column !== false) {
+            while ($item_column = mysqli_fetch_row($res_column)) {
+    
+                if ($item_column[0] == "HARDWARE_ID" && !isset($_SESSION['OCS']['SQL_TABLE_HARDWARE_ID'][$item[0]])) {
+                    $_SESSION['OCS']['SQL_TABLE_HARDWARE_ID'][$item[0]] = $item[0];
+                }
+    
+                $_SESSION['OCS']['SQL_TABLE'][$item[0]][$item_column[0]] = $item_column[0];
             }
-
-            $_SESSION['OCS']['SQL_TABLE'][$item[0]][$item_column[0]] = $item_column[0];
         }
     }
 }


### PR DESCRIPTION
### Status
**READY**

### Description
Fix error 500 on logout based on the following trace
```
PHP Fatal error:  Uncaught TypeError: mysqli_fetch_row(): Argument #1 ($result) must be of type mysqli_result, bool given in /app/reports/require/header.php:205 Stack trace:
#0 /app/reports/require/header.php(205): mysqli_fetch_row() #1 /app/reports/index.php(44): require('...')
#2 {main}
  thrown in /app/reports/require/header.php on line 205
```

### Documentation



