### PR TITLE
PHP Deprecated:  Creation of dynamic property

### DIFF
--- a/require/cve/Cve.php
+++ b/require/cve/Cve.php
@@ -23,6 +23,7 @@
 /**
  * Class for cve-search
  */
+#[AllowDynamicProperties]
 class Cve
 {
   public $CVE_SEARCH_URL = '';


### PR DESCRIPTION
In PHP 8.2, the creation of dynamic properties is deprecated unless the class explicitly allows them by using the `#[AllowDynamicProperties]` attribute.

### Status
**READY**

### Description
If cron_cve.php is executed, there is a deprecated message thrown

`PHP Deprecated:  Creation of dynamic property Cve::$var is deprecated in /usr/share/ocsinventory-reports/ocsreports/require/cve/Cve.php on line 296`


