### PR TITLE
UI: Simplify main menu layout and navbar styles

### DIFF
--- a/config/main_menu.xml
+++ b/config/main_menu.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <menu>
-  <menu-elem id="ms_all_computers">
-    <label>g(2)</label>
-    <url>ms_all_computers</url>
+  <!-- ===================== DASHBOARD ===================== -->
+  <menu-elem id="ms_console">
+    <label>g(1600)</label>
+    <url>ms_console</url>
   </menu-elem>
-  <menu-elem id="ms_inventory">
+
+  <!-- ===================== PARC (Inventaire) ===================== -->
+  <menu-elem id="ms_parc">
     <label>g(728)</label>
-    <url>ms_inventory</url>
+    <url>ms_all_computers</url>
     <submenu>
+      <menu-elem id="ms_all_computers">
+        <label>g(2)</label>
+        <url>ms_all_computers</url>
+      </menu-elem>
       <menu-elem id="ms_multi_search">
         <label>g(9)</label>
         <url>ms_multi_search</url>
@@ -16,6 +23,26 @@
         <label>g(765)</label>
         <url>ms_all_soft</url>
       </menu-elem>
+      <menu-elem id="ms_saas_soft">
+        <label>g(8100)</label>
+        <url>ms_saas_soft</url>
+      </menu-elem>
+      <menu-elem id="ms_groups">
+        <label>g(583)</label>
+        <url>ms_groups</url>
+      </menu-elem>
+      <menu-elem id="ms_repart_tag">
+        <label>g(178)</label>
+        <url>ms_repart_tag</url>
+      </menu-elem>
+    </submenu>
+  </menu-elem>
+
+  <!-- ===================== RÉSEAU ===================== -->
+  <menu-elem id="ms_reseau">
+    <label>g(82)</label>
+    <url>ms_ipdiscover</url>
+    <submenu>
       <menu-elem id="ms_ipdiscover">
         <label>g(1204)</label>
         <url>ms_ipdiscover</url>
@@ -24,24 +51,18 @@
         <label>g(1136)</label>
         <url>ms_snmp_inventory</url>
       </menu-elem>
-      <menu-elem id="ms_groups">
-        <label>g(583)</label>
-        <url>ms_groups</url>
+      <menu-elem id="ms_admin_ipdiscover">
+        <label>g(1139)</label>
+        <url>ms_admin_ipdiscover</url>
       </menu-elem>
-      <menu-elem id="ms_cve_search">
-        <label>g(1463)</label>
-        <url>ms_cve_search</url>
-      </menu-elem>
-      <menu-elem id="ms_saas_soft">
-        <label>g(8100)</label>
-        <url>ms_saas_soft</url>
-      </menu-elem>
-      <menu-elem id="ms_repart_tag">
-        <label>g(178)</label>
-        <url>ms_repart_tag</url>
+      <menu-elem id="ms_snmp_config">
+        <label>g(9000)</label>
+        <url>ms_snmp_config</url>
       </menu-elem>
     </submenu>
   </menu-elem>
+
+  <!-- ===================== DÉPLOIEMENT ===================== -->
   <menu-elem id="deployment">
     <label>g(512)</label>
     <url>ms_teledeploy</url>
@@ -60,7 +81,37 @@
       </menu-elem>
     </submenu>
   </menu-elem>
-  <menu-elem id="config">
+
+  <!-- ===================== SÉCURITÉ ===================== -->
+  <menu-elem id="security">
+    <label>g(174)</label>
+    <url>ms_cve_search</url>
+    <submenu>
+      <menu-elem id="ms_cve_search">
+        <label>g(1463)</label>
+        <url>ms_cve_search</url>
+      </menu-elem>
+      <menu-elem id="ms_cve_correspondance">
+        <label>g(1472)</label>
+        <url>ms_cve_correspondance</url>
+      </menu-elem>
+      <menu-elem id="ms_cve_history">
+        <label>g(1481)</label>
+        <url>ms_cve_history</url>
+      </menu-elem>
+      <menu-elem id="ms_doubles">
+        <label>g(175)</label>
+        <url>ms_doubles</url>
+      </menu-elem>
+      <menu-elem id="ms_blacklist">
+        <label>g(703)</label>
+        <url>ms_blacklist</url>
+      </menu-elem>
+    </submenu>
+  </menu-elem>
+
+  <!-- ===================== ADMINISTRATION ===================== -->
+  <menu-elem id="admin">
     <label>g(107)</label>
     <url>ms_config</url>
     <submenu>
@@ -68,107 +119,65 @@
         <label>g(1449)</label>
         <url>ms_config</url>
       </menu-elem>
-      <menu-elem id="ms_snmp_config">
-        <label>g(9000)</label>
-        <url>ms_snmp_config</url>
-      </menu-elem>
-      <menu-elem id="ms_notification">
-        <label>g(8000)</label>
-        <url>ms_notification</url>
-      </menu-elem>
       <menu-elem id="ms_users">
         <label>g(1410)</label>
         <url>ms_users</url>
-      </menu-elem>
-      <menu-elem id="ms_blacklist">
-        <label>g(703)</label>
-        <url>ms_blacklist</url>
-      </menu-elem>
-      <menu-elem id="ms_label">
-        <label>g(263)</label>
-        <url>ms_label</url>
-      </menu-elem>
-      <menu-elem id="ms_upload_file">
-        <label>g(17)</label>
-        <url>ms_upload_file</url>
-      </menu-elem>
-    </submenu>
-  </menu-elem>
-  <menu-elem id="manage">
-    <label>g(1328)</label>
-    <url>ms_regconfig</url>
-    <submenu>
-      <menu-elem id="ms_asset_cat_list">
-        <label>g(2130)</label>
-        <url>ms_asset_cat_list</url>
-      </menu-elem>
-      <menu-elem id="ms_soft_cat">
-        <label>g(1500)</label>
-        <url>ms_soft_cat</url>
-      </menu-elem>
-      <menu-elem id="ms_dict">
-        <label>g(380)</label>
-        <url>ms_dict</url>
       </menu-elem>
       <menu-elem id="ms_admininfo">
         <label>g(56)</label>
         <url>ms_admininfo</url>
       </menu-elem>
-      <menu-elem id="ms_admin_ipdiscover">
-        <label>g(1139)</label>
-        <url>ms_admin_ipdiscover</url>
+      <menu-elem id="ms_soft_cat">
+        <label>g(1500)</label>
+        <url>ms_soft_cat</url>
       </menu-elem>
-      <menu-elem id="ms_cve_correspondance">
-        <label>g(1472)</label>
-        <url>ms_cve_correspondance</url>
+      <menu-elem id="ms_asset_cat_list">
+        <label>g(2130)</label>
+        <url>ms_asset_cat_list</url>
+      </menu-elem>
+      <menu-elem id="ms_dict">
+        <label>g(380)</label>
+        <url>ms_dict</url>
       </menu-elem>
       <menu-elem id="ms_regconfig">
         <label>g(211)</label>
         <url>ms_regconfig</url>
       </menu-elem>
-      <menu-elem id="ms_save_query_list">
-        <label>g(2141)</label>
-        <url>ms_save_query_list</url>
+      <menu-elem id="ms_notification">
+        <label>g(8000)</label>
+        <url>ms_notification</url>
       </menu-elem>
-      <menu-elem id="ms_doubles">
-        <label>g(175)</label>
-        <url>ms_doubles</url>
-      </menu-elem>
-      <menu-elem id="ms_local_import">
-        <label>g(287)</label>
-        <url>ms_local_import</url>
+      <menu-elem id="ms_label">
+        <label>g(263)</label>
+        <url>ms_label</url>
       </menu-elem>
       <menu-elem id="ms_layouts">
         <label>g(9900)</label>
         <url>ms_layouts</url>
       </menu-elem>
-    </submenu>
-  </menu-elem>
-  <menu-elem id="extension">
-    <label>g(7000)</label>
-    <url>ms_extension</url>
-    <submenu>
-      <menu-elem id="ms_extensionmanager">
-    	<label>g(7001)</label>
-    	<url>ms_extensionmanager</url>
+      <menu-elem id="ms_upload_file">
+        <label>g(17)</label>
+        <url>ms_upload_file</url>
       </menu-elem>
-    </submenu>
-  </menu-elem>
-  <menu-elem id="info">
-    <label>g(223)</label>
-    <url>ms_logs</url>
-    <submenu>
+      <menu-elem id="ms_local_import">
+        <label>g(287)</label>
+        <url>ms_local_import</url>
+      </menu-elem>
+      <menu-elem id="ms_save_query_list">
+        <label>g(2141)</label>
+        <url>ms_save_query_list</url>
+      </menu-elem>
+      <menu-elem id="ms_extensionmanager">
+        <label>g(7001)</label>
+        <url>ms_extensionmanager</url>
+      </menu-elem>
       <menu-elem id="ms_logs">
         <label>g(928)</label>
         <url>ms_logs</url>
       </menu-elem>
-       <menu-elem id="ms_server_infos">
+      <menu-elem id="ms_server_infos">
         <label>g(1360)</label>
         <url>ms_server_infos</url>
-      </menu-elem>
-      <menu-elem id="ms_cve_history">
-        <label>g(1481)</label>
-        <url>ms_cve_history</url>
       </menu-elem>
       <menu-elem id="ms_history">
         <label>g(9651)</label>
@@ -176,6 +185,8 @@
       </menu-elem>
     </submenu>
   </menu-elem>
+
+  <!-- ===================== AIDE ===================== -->
   <menu-elem id="ms_help">
     <label>g(570)</label>
     <url>ms_help</url>

--- a/css/header.css
+++ b/css/header.css
@@ -35,8 +35,10 @@
 /*** OVERRIDE BOOTSTRAP ***/
 .navbar-default{
     background-color: #fff !important;
-    box-shadow: none !important;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08) !important;
     background-image: none;
+    border-bottom: 1px solid #e0e0e0;
+    margin-bottom: 0;
 }
 
 .main-menu-container {
@@ -44,7 +46,7 @@
 }
 
 .main-menu-container .navbar {
-    margin-bottom: 10px;
+    margin-bottom: 0;
 }
 
 .main-menu-container .navbar-nav > li {
@@ -55,12 +57,55 @@
 .main-menu-container .navbar-nav > li > a {
     padding-top: 14px;
     padding-bottom: 14px;
+    color: #424242 !important;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    border-bottom: 3px solid transparent;
+}
+
+.main-menu-container .navbar-nav > li > a:hover {
+    color: #961b7e !important;
+    background-color: rgba(150, 27, 126, 0.05) !important;
+    border-bottom: 3px solid transparent;
+}
+
+.navbar-default .navbar-nav > .active > a,
+.navbar-default .navbar-nav > .active > a:hover,
+.navbar-default .navbar-nav > .active > a:focus,
+.navbar-default .navbar-nav > .open > a,
+.navbar-default .navbar-nav > .open > a:hover,
+.navbar-default .navbar-nav > .open > a:focus {
+    color: #961b7e !important;
+    background-color: rgba(150, 27, 126, 0.08) !important;
+    border-bottom: 3px solid #961b7e;
+}
+
+/* Menu déroulant */
+.dropdown-menu {
+    border: 1px solid #e0e0e0;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    padding: 8px 0;
+}
+
+.dropdown-menu > li > a {
+    padding: 8px 20px;
+    color: #424242;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+    background-color: rgba(150, 27, 126, 0.05);
+    color: #961b7e;
 }
 
 .user-header {
-    background: black;
-    color: white;
+    background: #20222e;
+    color: #bdbdbd;
     min-height: 15px;
+    font-size: 11px;
+    letter-spacing: 0.3px;
 }
 
 .user-header .version,
@@ -71,10 +116,20 @@
 
 .user-header .links > * {
     margin: 0 10px;
-    color: white;
+    color: #bdbdbd;
     float: right;
+    transition: color 0.2s ease;
+}
+
+.user-header .links > *:hover {
+    color: #fff;
 }
 
 #menu_settings{
     font-size:20px;
+    transition: color 0.2s ease;
+}
+
+#menu_settings:hover {
+    color: #961b7e !important;
 }


### PR DESCRIPTION
### Status
READY
### Description
Reorganized the main menu to make it less cluttered

- Grouped original menus into 7 main categories (Dashboard, Parc, Réseau, Déploiement, Sécurité, Administration, Aide) in `config/main_menu.xml`.
- Added some basic CSS to `css/header.css` to improve the navbar look (hover states, dark admin header, light drop shadow).



### Documentation
No documentation changes needed 


